### PR TITLE
JSONP support

### DIFF
--- a/README
+++ b/README
@@ -49,6 +49,13 @@ push_publisher
   location are treated as messages to be sent to subscribers. See the protocol 
   documentation for a detailed description. 
 
+push_jsonp
+  default: none
+  context: server, location
+  Defines a server or location as a JSONP subscriber. This makes a subscriber
+  take into account a callback parameter usually given by "&callback=", and
+  convert publisher's posts to JSONP responses by wrapping with it.
+
 == Message storage ==
 
 push_store_messages [ on | off ]
@@ -173,6 +180,25 @@ http {
     push_subscriber_concurrency broadcast;
     set $push_channel_id $arg_channel; #/?channel=239aff3 or some-such
     default_type  text/plain;
+  }
+
+  # public long-polling JSONP endpoint
+  location /jsonp {
+    push_subscriber;
+    push_subscriber_concurrency broadcast;
+    set $push_channel_id $arg_channel; #/?channel=239aff3 or some-such
+
+    # For cross-domain XHR, you'd need to use JSONP, and you'd not be allowed to
+    # read/write headers such as "If-Modified-Since" and "If-None-Match".
+    # In that case, you can pass them via GET parameters along with "callback".
+    # This endpoint will return something like below.
+    # e.g.) jsonp12345([{"foo": 1, "bar": 2, "baz": 3},"Wed, 16 Feb 2011 09:02:29 GMT","0"]);
+    push_jsonp;
+    set $push_jsonp_callback $arg_callback; #/?callback=jsonp12345
+    set $push_jsonp_if_modified_since $arg_since; #/?since=Wed,%2016%20Feb%202011%2009:01:06%20GMT
+    set $push_jsonp_if_none_match $arg_etag; #/?etag=1
+    default_type text/javascript;
+    charset utf-8;
   }
 }
 

--- a/src/ngx_http_push_module.c
+++ b/src/ngx_http_push_module.c
@@ -19,7 +19,6 @@ static void ngx_http_push_clean_timeouted_subscriber(ngx_event_t *ev)
 {
 	ngx_http_push_subscriber_t *subscriber = NULL;
 	ngx_http_request_t *r = NULL;
-	ngx_chain_t *chain = NULL;
 
 	subscriber = ev->data;
 	r = subscriber->request;
@@ -551,7 +550,7 @@ static ngx_int_t ngx_http_push_handle_subscriber_concurrency(ngx_http_request_t 
 			//in most reasonable cases, there'll be at most one subscriber on the
 			//channel. However, since settings are bound to locations and not
 			//specific channels, this assumption need not hold. Hence this broadcast.
-			ngx_int_t rc = ngx_http_push_broadcast_status_locked(channel, NGX_HTTP_NOT_FOUND, &NGX_HTTP_PUSH_HTTP_STATUS_409, r->connection->log, ngx_http_push_shpool);
+			ngx_http_push_broadcast_status_locked(channel, NGX_HTTP_NOT_FOUND, &NGX_HTTP_PUSH_HTTP_STATUS_409, r->connection->log, ngx_http_push_shpool);
 			ngx_shmtx_unlock(&ngx_http_push_shpool->mutex);
 
 			return NGX_OK;

--- a/src/ngx_http_push_module.c
+++ b/src/ngx_http_push_module.c
@@ -1234,7 +1234,7 @@ static ngx_int_t ngx_http_push_apply_jsonp_to_chain(ngx_chain_t **chainp, ngx_po
 	ngx_buf_t                      *buf_head = NULL;
 	ngx_buf_t                      *buf_foot = NULL;
 
-	if (!jsonp_callback) {
+	if (!jsonp_callback || !ngx_buf_size(body->buf)) {
 		return NGX_OK;
 	}
 	if ((head = ngx_pcalloc(pool, sizeof(*head)))==NULL) {
@@ -1292,12 +1292,11 @@ static ngx_int_t ngx_http_push_clear_jsonp_from_chain(ngx_chain_t **chainp, ngx_
 	ngx_chain_t                    *body;
 	ngx_chain_t                    *foot;
 
-	return NGX_OK;
 	if (!head->next) {
 		return NGX_ERROR;
 	}
 	body = head->next;
-	if (body->next) {
+	if (!body->next) {
 		return NGX_ERROR;
 	}
 	foot = body->next;

--- a/src/ngx_http_push_module.c
+++ b/src/ngx_http_push_module.c
@@ -162,13 +162,11 @@ static ngx_inline void ngx_http_push_free_message_locked(ngx_http_push_msg_t *ms
 /** find message with entity tags matching those of the request r.
   * @param r subscriber request
   */
-static ngx_http_push_msg_t * ngx_http_push_find_message_locked(ngx_http_push_channel_t *channel, ngx_http_request_t *r, ngx_int_t *status) {
+static ngx_http_push_msg_t * ngx_http_push_find_message_locked(ngx_http_push_channel_t *channel, ngx_http_request_t *r, ngx_int_t *status, time_t time, ngx_int_t tag) {
 	//TODO: consider using an RBTree for message storage.
 	ngx_queue_t                    *sentinel = &channel->message_queue->queue;
 	ngx_queue_t                    *cur = ngx_queue_head(sentinel);
 	ngx_http_push_msg_t            *msg;
-	ngx_int_t                       tag = -1;
-	time_t                          time = (r->headers_in.if_modified_since == NULL) ? 0 : ngx_http_parse_time(r->headers_in.if_modified_since->value.data, r->headers_in.if_modified_since->value.len);
 	
 	//channel's message buffer empty?
 	if(channel->messages==0) {
@@ -180,7 +178,6 @@ static ngx_http_push_msg_t * ngx_http_push_find_message_locked(ngx_http_push_cha
 	msg = ngx_queue_data(sentinel->prev, ngx_http_push_msg_t, queue); 
 	if(time <= msg->message_time) { //that's an empty check (Sentinel's values are zero)
 		if(time == msg->message_time) {
-			if(tag<0) { tag = ngx_http_push_subscriber_get_etag_int(r); }
 			if(tag >= msg->message_tag) {
 				*status=NGX_HTTP_PUSH_MESSAGE_EXPECTED;
 				return NULL;
@@ -199,7 +196,6 @@ static ngx_http_push_msg_t * ngx_http_push_find_message_locked(ngx_http_push_cha
 			return msg;
 		}
 		else if(time == msg->message_time) {
-			if(tag<0) { tag = ngx_http_push_subscriber_get_etag_int(r); }
 			while (tag >= msg->message_tag  && time == msg->message_time && ngx_queue_next(cur)!=sentinel) {
 				cur=ngx_queue_next(cur);
 				msg = ngx_queue_data(cur, ngx_http_push_msg_t, queue);
@@ -265,9 +261,9 @@ static ngx_str_t * ngx_http_push_get_jsonp_callback(ngx_http_request_t *r, ngx_h
 	ngx_http_variable_value_t      *vv;
 	size_t                          var_len;
 	ngx_str_t                      *id;
-	if (cf->jsonp == NGX_ERROR) return NULL;
+	if (!cf->jsonp || cf->jsonp_callback == NGX_ERROR) return NULL;
 
-	vv = ngx_http_get_indexed_variable(r, cf->jsonp);
+	vv = ngx_http_get_indexed_variable(r, cf->jsonp_callback);
 	if (vv == NULL || vv->not_found || vv->len == 0) {
 		return NULL;
 	}
@@ -285,6 +281,50 @@ static ngx_str_t * ngx_http_push_get_jsonp_callback(ngx_http_request_t *r, ngx_h
 	id->data[var_len] = '\0';
 	return id;
 }
+
+static time_t ngx_http_push_get_if_modified_since(ngx_http_request_t *r, ngx_http_push_loc_conf_t *cf) {
+	ngx_http_variable_value_t      *vv;
+
+	if (r->headers_in.if_modified_since) {
+		return ngx_http_parse_time(r->headers_in.if_modified_since->value.data, r->headers_in.if_modified_since->value.len);
+	}
+	if (cf->jsonp && cf->jsonp_if_modified_since != NGX_ERROR) {
+		vv = ngx_http_get_indexed_variable(r, cf->jsonp_if_modified_since);
+		if (vv || !vv->not_found || vv->len) {
+			return ngx_http_parse_time(vv->data, vv->len);
+		}
+	}
+	return 0;
+}
+
+static ngx_str_t * ngx_http_push_get_if_none_match(ngx_http_request_t *r, ngx_http_push_loc_conf_t *cf) {
+	ngx_http_variable_value_t      *vv;
+	size_t                          var_len;
+	ngx_str_t                      *id;
+
+	if (r->headers_in.if_modified_since) {
+		return ngx_http_push_subscriber_get_etag(r);
+	}
+
+	if (!cf->jsonp || cf->jsonp_if_none_match == NGX_ERROR) return NULL;
+
+	vv = ngx_http_get_indexed_variable(r, cf->jsonp_if_none_match);
+	if (vv == NULL || vv->not_found || vv->len == 0) {
+		return NULL;
+	}
+
+	if ((id = ngx_palloc(r->pool, sizeof(*id) + NGX_INT_T_LEN + 1)) == NULL) {
+		ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+			      "push module: unable to allocate memory for $push_jsonp_if_none_match");
+		return NULL;
+	}
+	id->len = vv->len;
+	id->data = (u_char *)(id+1);
+	ngx_memcpy(id->data, vv->data, var_len);
+	id->data[vv->len] = '\0';
+	return id;
+}
+
 
 #define NGX_HTTP_PUSH_MAKE_ETAG(message_tag, etag, alloc_func, pool)                 \
     etag = alloc_func(pool, sizeof(*etag) + NGX_INT_T_LEN);                          \
@@ -312,6 +352,8 @@ static ngx_int_t ngx_http_push_subscriber_handler(ngx_http_request_t *r) {
 	
 	ngx_str_t                      *content_type=NULL;
 	ngx_str_t                      *etag;
+	time_t                          if_modified_since;
+	ngx_int_t                       if_none_match;
 	
     if (r->method == NGX_HTTP_OPTIONS) {
         ngx_buf_t *buf = ngx_create_temp_buf(r->pool, sizeof(NGX_HTTP_PUSH_OPTIONS_OK_MESSAGE));
@@ -356,7 +398,10 @@ static ngx_int_t ngx_http_push_subscriber_handler(ngx_http_request_t *r) {
 		}
 	}
 
-    msg = ngx_http_push_find_message_locked(channel, r, &msg_search_outcome); 
+    if_modified_since = ngx_http_push_get_if_modified_since(r, cf);
+    etag = ngx_http_push_get_if_none_match(r, cf);
+    if_none_match = ngx_http_push_subscriber_get_etag_int(etag);
+    msg = ngx_http_push_find_message_locked(channel, r, &msg_search_outcome, if_modified_since, if_none_match);
     channel->last_seen = ngx_time();
     channel->expires = ngx_time() + cf->channel_timeout;
     ngx_shmtx_unlock(&shpool->mutex);
@@ -380,7 +425,6 @@ static ngx_int_t ngx_http_push_subscriber_handler(ngx_http_request_t *r) {
 		ngx_chain_t                *chain;
 		time_t                      last_modified;
 		size_t                      content_type_len;
-		ngx_str_t                  *jsonp_callback;
 
 		case NGX_HTTP_PUSH_MESSAGE_EXPECTED:
 			// ♫ It's gonna be the future soon ♫
@@ -473,10 +517,10 @@ static ngx_int_t ngx_http_push_subscriber_handler(ngx_http_request_t *r) {
 				case NGX_HTTP_PUSH_MECHANISM_INTERVALPOLL:
 				
 					//interval-polling subscriber requests get a 304 with their entity tags preserved.
-					if (r->headers_in.if_modified_since != NULL) {
-						r->headers_out.last_modified_time=ngx_http_parse_time(r->headers_in.if_modified_since->value.data, r->headers_in.if_modified_since->value.len);
+					if (if_modified_since) {
+						r->headers_out.last_modified_time=if_modified_since;
 					}
-					if ((etag=ngx_http_push_subscriber_get_etag(r)) != NULL) {
+					if (etag) {
 						r->headers_out.etag=ngx_http_push_add_response_header(r, &NGX_HTTP_PUSH_HEADER_ETAG, etag);
 					}
 					return NGX_HTTP_NOT_MODIFIED;
@@ -541,9 +585,11 @@ static ngx_int_t ngx_http_push_subscriber_handler(ngx_http_request_t *r) {
 				clnf->log = r->pool->log;
 			}
 			
-			jsonp_callback = ngx_http_push_get_jsonp_callback(r, cf);
-			if (ngx_http_push_apply_jsonp_to_chain(&chain, r->pool, jsonp_callback) == NGX_ERROR) {
-				return NGX_HTTP_INTERNAL_SERVER_ERROR;
+			if (cf->jsonp) {
+				ngx_str_t *jsonp_callback = ngx_http_push_get_jsonp_callback(r, cf);
+				if (ngx_http_push_apply_jsonp_to_chain(&chain, r->pool, jsonp_callback, etag, last_modified) == NGX_ERROR) {
+					return NGX_HTTP_INTERNAL_SERVER_ERROR;
+				}
 			}
 			return ngx_http_push_prepare_response_to_subscriber_request(r, chain, content_type, etag, last_modified);
 			
@@ -903,7 +949,6 @@ static ngx_int_t ngx_http_push_respond_to_subscribers(ngx_http_push_channel_t *c
 		ngx_buf_t                  *buffer;
 		u_char                     *pos;
 		ngx_http_push_loc_conf_t   *cf;
-		ngx_str_t                  *jsonp_callback;
 		
 		ngx_shmtx_lock(&shpool->mutex);
 		
@@ -954,12 +999,15 @@ static ngx_int_t ngx_http_push_respond_to_subscribers(ngx_http_push_channel_t *c
 			r->discard_body=0; //hacky hacky!
 			
 			cf = ngx_http_get_module_loc_conf(r, ngx_http_push_module);
-			jsonp_callback = ngx_http_push_get_jsonp_callback(r, cf);
-			if (ngx_http_push_apply_jsonp_to_chain(&chain, ngx_http_push_pool, jsonp_callback) == NGX_OK) {
-				ngx_http_finalize_request(r, ngx_http_push_prepare_response_to_subscriber_request(r, chain, content_type, etag, last_modified_time)); //BAM!
-				ngx_http_push_clear_jsonp_from_chain(&chain, ngx_http_push_pool);
-			} else {
-				ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "push module: unable to create jsonp callback");
+			
+			if (cf->jsonp) {
+				ngx_str_t *jsonp_callback = ngx_http_push_get_jsonp_callback(r, cf);
+				if (ngx_http_push_apply_jsonp_to_chain(&chain, ngx_http_push_pool, jsonp_callback, etag, last_modified_time) == NGX_OK) {
+					ngx_http_finalize_request(r, ngx_http_push_prepare_response_to_subscriber_request(r, chain, content_type, etag, last_modified_time)); //BAM!
+					ngx_http_push_clear_jsonp_from_chain(&chain, ngx_http_push_pool);
+				} else {
+					ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "push module: unable to create jsonp callback");
+				}
 			}
 			responded_subscribers++;
 			
@@ -1119,8 +1167,7 @@ static ngx_table_elt_t * ngx_http_push_add_response_header(ngx_http_request_t *r
 	return h;
 }
 
-static ngx_int_t ngx_http_push_subscriber_get_etag_int(ngx_http_request_t * r) {
-	ngx_str_t                      *if_none_match = ngx_http_push_subscriber_get_etag(r);
+static ngx_int_t ngx_http_push_subscriber_get_etag_int(ngx_str_t *if_none_match) {
 	ngx_int_t                       tag;
 	if(if_none_match==NULL || (if_none_match!=NULL && (tag = ngx_atoi(if_none_match->data, if_none_match->len))==NGX_ERROR)) {
 		tag=0;
@@ -1227,7 +1274,7 @@ static ngx_chain_t * ngx_http_push_create_output_chain_general(ngx_buf_t *buf, n
 	return out;	
 }
 
-static ngx_int_t ngx_http_push_apply_jsonp_to_chain(ngx_chain_t **chainp, ngx_pool_t *pool, ngx_str_t *jsonp_callback) {
+static ngx_int_t ngx_http_push_apply_jsonp_to_chain(ngx_chain_t **chainp, ngx_pool_t *pool, ngx_str_t *jsonp_callback, ngx_str_t *etag, time_t last_modified) {
 	ngx_chain_t                    *head = NULL;
 	ngx_chain_t                    *body = *chainp;
 	ngx_chain_t                    *foot = NULL;
@@ -1243,16 +1290,42 @@ static ngx_int_t ngx_http_push_apply_jsonp_to_chain(ngx_chain_t **chainp, ngx_po
 	if ((foot = ngx_pcalloc(pool, sizeof(*foot)))==NULL) {
 		goto FAILED_TO_APPLY_JSONP;
 	}
-	if ((buf_head = ngx_create_temp_buf(pool, jsonp_callback->len + 1))==NULL) {
+	if ((buf_head = ngx_pcalloc(pool, sizeof(*buf_head) + jsonp_callback->len + 2))==NULL) {
 		goto FAILED_TO_APPLY_JSONP;
 	}
-	if ((buf_foot = ngx_create_temp_buf(pool, 200))==NULL) {
+	if ((buf_foot = ngx_pcalloc(pool, sizeof(*buf_foot) + 200))==NULL) {
 		goto FAILED_TO_APPLY_JSONP;
 	}
 
+	buf_head->start = (u_char *) (buf_head+1);
+	buf_head->end = buf_head->start + jsonp_callback->len + 2;
+	buf_head->last = buf_head->pos = buf_head->start;
+	buf_head->temporary = 1;
+
+	buf_foot->start = (u_char *) (buf_foot+1);
+	buf_foot->end = buf_foot->start + 200;
+	buf_foot->last = buf_foot->pos = buf_foot->start;
+	buf_foot->temporary = 1;
+
 	ngx_memcpy(buf_head->last, jsonp_callback->data, jsonp_callback->len);
-	buf_head->last[jsonp_callback->len] = '(';
-	buf_head->last = buf_head->last + jsonp_callback->len + 1;
+	buf_head->last = buf_head->last + jsonp_callback->len;
+	*(buf_head->last++) = '(';
+	*(buf_head->last++) = '[';
+
+	*(buf_foot->last++) = ',';
+	*(buf_foot->last++) = '"';
+	if (last_modified) {
+		buf_foot->last = ngx_http_time(buf_foot->last, last_modified);
+	}
+	*(buf_foot->last++) = '"';
+	*(buf_foot->last++) = ',';
+	*(buf_foot->last++) = '"';
+	if (etag->data) {
+		ngx_memcpy(buf_foot->last, etag->data, etag->len);
+		buf_foot->last += etag->len;
+	}
+	*(buf_foot->last++) = '"';
+	*(buf_foot->last++) = ']';
 	*(buf_foot->last++) = ')';
 	*(buf_foot->last++) = ';';
 

--- a/src/ngx_http_push_module.c
+++ b/src/ngx_http_push_module.c
@@ -291,6 +291,11 @@ static time_t ngx_http_push_get_if_modified_since(ngx_http_request_t *r, ngx_htt
 	if (cf->jsonp && cf->jsonp_if_modified_since != NGX_ERROR) {
 		vv = ngx_http_get_indexed_variable(r, cf->jsonp_if_modified_since);
 		if (vv || !vv->not_found || vv->len) {
+			u_char *src, *dst;
+			src = vv->data;
+			dst = vv->data;
+			ngx_unescape_uri(&dst, &dst, vv->len, NGX_UNESCAPE_URI);
+			vv->len = dst - vv->data;
 			return ngx_http_parse_time(vv->data, vv->len);
 		}
 	}

--- a/src/ngx_http_push_module.h
+++ b/src/ngx_http_push_module.h
@@ -70,6 +70,9 @@ typedef struct {
 	ngx_int_t                       ignore_queue_on_no_cache;
 	time_t                          channel_timeout;
 	ngx_int_t                       jsonp;
+	ngx_int_t                       jsonp_callback;
+  	ngx_int_t                       jsonp_if_modified_since;
+  	ngx_int_t                       jsonp_if_none_match;
 	ngx_int_t                       max_jsonp_callback_length;
 } ngx_http_push_loc_conf_t;
 
@@ -162,7 +165,7 @@ static ngx_inline void ngx_http_push_general_delete_message_locked(ngx_http_push
 #define ngx_http_push_delete_message_locked(channel, msg, shpool) ngx_http_push_general_delete_message_locked(channel, msg, 0, shpool)
 #define ngx_http_push_force_delete_message_locked(channel, msg, shpool) ngx_http_push_general_delete_message_locked(channel, msg, 1, shpool)
 static ngx_inline void ngx_http_push_free_message_locked(ngx_http_push_msg_t *msg, ngx_slab_pool_t *shpool);
-static ngx_http_push_msg_t * ngx_http_push_find_message_locked(ngx_http_push_channel_t *channel, ngx_http_request_t *r, ngx_int_t *status);
+static ngx_http_push_msg_t * ngx_http_push_find_message_locked(ngx_http_push_channel_t *channel, ngx_http_request_t *r, ngx_int_t *status, time_t time, ngx_int_t tag);
 
 //channel
 static ngx_str_t * ngx_http_push_get_channel_id(ngx_http_request_t *r, ngx_http_push_loc_conf_t *cf);
@@ -170,7 +173,7 @@ static ngx_int_t ngx_http_push_channel_info(ngx_http_request_t *r, ngx_uint_t me
 
 // jsonp
 static ngx_str_t * ngx_http_push_get_jsonp_callback(ngx_http_request_t *r, ngx_http_push_loc_conf_t *cf);
-static ngx_int_t ngx_http_push_apply_jsonp_to_chain(ngx_chain_t **chainp, ngx_pool_t *pool, ngx_str_t *jsonp_callback);
+static ngx_int_t ngx_http_push_apply_jsonp_to_chain(ngx_chain_t **chainp, ngx_pool_t *pool, ngx_str_t *jsonp_callback, ngx_str_t *etag, time_t last_modified);
 static ngx_int_t ngx_http_push_clear_jsonp_from_chain(ngx_chain_t **chainp, ngx_pool_t *pool);
 
 //subscriber
@@ -182,7 +185,7 @@ static ngx_int_t ngx_http_push_broadcast_locked(ngx_http_push_channel_t *channel
 
 static ngx_int_t ngx_http_push_respond_to_subscribers(ngx_http_push_channel_t *channel, ngx_http_push_subscriber_t *sentinel, ngx_http_push_msg_t *msg, ngx_int_t status_code, const ngx_str_t *status_line);
 static ngx_int_t ngx_http_push_allow_caching(ngx_http_request_t * r);
-static ngx_int_t ngx_http_push_subscriber_get_etag_int(ngx_http_request_t * r);
+static ngx_int_t ngx_http_push_subscriber_get_etag_int(ngx_str_t *if_none_match);
 static ngx_str_t * ngx_http_push_subscriber_get_etag(ngx_http_request_t * r);
 static void ngx_http_push_subscriber_cleanup(ngx_http_push_subscriber_cleanup_t *data);
 static ngx_int_t ngx_http_push_prepare_response_to_subscriber_request(ngx_http_request_t *r, ngx_chain_t *chain, ngx_str_t *content_type, ngx_str_t *etag, time_t last_modified);

--- a/src/ngx_http_push_module.h
+++ b/src/ngx_http_push_module.h
@@ -22,6 +22,7 @@
 #define NGX_HTTP_PUSH_MIN_MESSAGE_RECIPIENTS 0
 
 #define NGX_HTTP_PUSH_MAX_CHANNEL_ID_LENGTH 1024 //bytes
+#define NGX_HTTP_PUSH_MAX_JSONP_CALLBACK_LENGTH 1024 //bytes
 
 #ifndef NGX_HTTP_CONFLICT
 #define NGX_HTTP_CONFLICT 409
@@ -68,6 +69,8 @@ typedef struct {
 	ngx_int_t                       max_channel_subscribers;
 	ngx_int_t                       ignore_queue_on_no_cache;
 	time_t                          channel_timeout;
+	ngx_int_t                       jsonp;
+	ngx_int_t                       max_jsonp_callback_length;
 } ngx_http_push_loc_conf_t;
 
 //message queue
@@ -164,6 +167,11 @@ static ngx_http_push_msg_t * ngx_http_push_find_message_locked(ngx_http_push_cha
 //channel
 static ngx_str_t * ngx_http_push_get_channel_id(ngx_http_request_t *r, ngx_http_push_loc_conf_t *cf);
 static ngx_int_t ngx_http_push_channel_info(ngx_http_request_t *r, ngx_uint_t message_queue_size, ngx_uint_t subscriber_queue_size, time_t last_seen);
+
+// jsonp
+static ngx_str_t * ngx_http_push_get_jsonp_callback(ngx_http_request_t *r, ngx_http_push_loc_conf_t *cf);
+static ngx_int_t ngx_http_push_apply_jsonp_to_chain(ngx_chain_t **chainp, ngx_pool_t *pool, ngx_str_t *jsonp_callback);
+static ngx_int_t ngx_http_push_clear_jsonp_from_chain(ngx_chain_t **chainp, ngx_pool_t *pool);
 
 //subscriber
 static ngx_int_t ngx_http_push_subscriber_handler(ngx_http_request_t *r);

--- a/src/ngx_http_push_module_setup.c
+++ b/src/ngx_http_push_module_setup.c
@@ -105,6 +105,7 @@ static void *		ngx_http_push_create_loc_conf(ngx_conf_t *cf) {
 	lcf->store_messages=NGX_CONF_UNSET;
 	lcf->delete_oldest_received_message=NGX_CONF_UNSET;
 	lcf->max_channel_id_length=NGX_CONF_UNSET;
+	lcf->max_jsonp_callback_length=NGX_CONF_UNSET;
 	lcf->max_channel_subscribers=NGX_CONF_UNSET;
 	lcf->ignore_queue_on_no_cache=NGX_CONF_UNSET;
 	lcf->channel_timeout=NGX_CONF_UNSET;
@@ -124,6 +125,7 @@ static char *	ngx_http_push_merge_loc_conf(ngx_conf_t *cf, void *parent, void *c
 	ngx_conf_merge_value(conf->store_messages, prev->store_messages, 1);
 	ngx_conf_merge_value(conf->delete_oldest_received_message, prev->delete_oldest_received_message, 0);
 	ngx_conf_merge_value(conf->max_channel_id_length, prev->max_channel_id_length, NGX_HTTP_PUSH_MAX_CHANNEL_ID_LENGTH);
+	ngx_conf_merge_value(conf->max_jsonp_callback_length, prev->max_channel_id_length, NGX_HTTP_PUSH_MAX_JSONP_CALLBACK_LENGTH);
 	ngx_conf_merge_value(conf->max_channel_subscribers, prev->max_channel_subscribers, 0);
 	ngx_conf_merge_value(conf->ignore_queue_on_no_cache, prev->ignore_queue_on_no_cache, 0);
 	ngx_conf_merge_value(conf->channel_timeout, prev->channel_timeout, NGX_HTTP_PUSH_DEFAULT_CHANNEL_TIMEOUT);
@@ -140,6 +142,7 @@ static char *	ngx_http_push_merge_loc_conf(ngx_conf_t *cf, void *parent, void *c
 }
 
 static ngx_str_t  ngx_http_push_channel_id = ngx_string("push_channel_id"); //channel id variable
+static ngx_str_t  ngx_http_push_jsonp_callback = ngx_string("push_jsonp_callback"); //jsonp callback variable
 //publisher and subscriber handlers now.
 static char *ngx_http_push_setup_handler(ngx_conf_t *cf, void * conf, ngx_int_t (*handler)(ngx_http_request_t *)) {
 	ngx_http_core_loc_conf_t       *clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
@@ -147,6 +150,7 @@ static char *ngx_http_push_setup_handler(ngx_conf_t *cf, void * conf, ngx_int_t 
 	clcf->handler = handler;
 	clcf->if_modified_since = NGX_HTTP_IMS_OFF;
 	plcf->index = ngx_http_get_variable_index(cf, &ngx_http_push_channel_id);
+	plcf->jsonp = ngx_http_get_variable_index(cf, &ngx_http_push_jsonp_callback);
 	if (plcf->index == NGX_ERROR) {
 		return NGX_CONF_ERROR;
 	}
@@ -357,6 +361,13 @@ static ngx_command_t  ngx_http_push_commands[] = {
       ngx_conf_set_num_slot,
       NGX_HTTP_LOC_CONF_OFFSET,
       offsetof(ngx_http_push_loc_conf_t, max_channel_id_length),
+      NULL },
+	  
+	{ ngx_string("push_max_jsonp_callback_length"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_push_loc_conf_t, max_jsonp_callback_length),
       NULL },
 	  
 	{ ngx_string("push_max_channel_subscribers"),

--- a/src/ngx_http_push_module_setup.c
+++ b/src/ngx_http_push_module_setup.c
@@ -105,6 +105,7 @@ static void *		ngx_http_push_create_loc_conf(ngx_conf_t *cf) {
 	lcf->store_messages=NGX_CONF_UNSET;
 	lcf->delete_oldest_received_message=NGX_CONF_UNSET;
 	lcf->max_channel_id_length=NGX_CONF_UNSET;
+	lcf->jsonp=NGX_CONF_UNSET;
 	lcf->max_jsonp_callback_length=NGX_CONF_UNSET;
 	lcf->max_channel_subscribers=NGX_CONF_UNSET;
 	lcf->ignore_queue_on_no_cache=NGX_CONF_UNSET;
@@ -125,6 +126,7 @@ static char *	ngx_http_push_merge_loc_conf(ngx_conf_t *cf, void *parent, void *c
 	ngx_conf_merge_value(conf->store_messages, prev->store_messages, 1);
 	ngx_conf_merge_value(conf->delete_oldest_received_message, prev->delete_oldest_received_message, 0);
 	ngx_conf_merge_value(conf->max_channel_id_length, prev->max_channel_id_length, NGX_HTTP_PUSH_MAX_CHANNEL_ID_LENGTH);
+	ngx_conf_merge_value(conf->jsonp, prev->jsonp, 0);
 	ngx_conf_merge_value(conf->max_jsonp_callback_length, prev->max_channel_id_length, NGX_HTTP_PUSH_MAX_JSONP_CALLBACK_LENGTH);
 	ngx_conf_merge_value(conf->max_channel_subscribers, prev->max_channel_subscribers, 0);
 	ngx_conf_merge_value(conf->ignore_queue_on_no_cache, prev->ignore_queue_on_no_cache, 0);
@@ -142,7 +144,6 @@ static char *	ngx_http_push_merge_loc_conf(ngx_conf_t *cf, void *parent, void *c
 }
 
 static ngx_str_t  ngx_http_push_channel_id = ngx_string("push_channel_id"); //channel id variable
-static ngx_str_t  ngx_http_push_jsonp_callback = ngx_string("push_jsonp_callback"); //jsonp callback variable
 //publisher and subscriber handlers now.
 static char *ngx_http_push_setup_handler(ngx_conf_t *cf, void * conf, ngx_int_t (*handler)(ngx_http_request_t *)) {
 	ngx_http_core_loc_conf_t       *clcf = ngx_http_conf_get_module_loc_conf(cf, ngx_http_core_module);
@@ -150,7 +151,6 @@ static char *ngx_http_push_setup_handler(ngx_conf_t *cf, void * conf, ngx_int_t 
 	clcf->handler = handler;
 	clcf->if_modified_since = NGX_HTTP_IMS_OFF;
 	plcf->index = ngx_http_get_variable_index(cf, &ngx_http_push_channel_id);
-	plcf->jsonp = ngx_http_get_variable_index(cf, &ngx_http_push_jsonp_callback);
 	if (plcf->index == NGX_ERROR) {
 		return NGX_CONF_ERROR;
 	}
@@ -220,6 +220,22 @@ static char *ngx_http_push_subscriber(ngx_conf_t *cf, ngx_command_t *cmd, void *
 	}
 	
 	return ngx_http_push_setup_handler(cf, conf, &ngx_http_push_subscriber_handler);
+}
+
+static ngx_str_t  ngx_http_push_jsonp_callback = ngx_string("push_jsonp_callback"); //jsonp callback id variable
+static ngx_str_t  ngx_http_push_jsonp_if_modified_since = ngx_string("push_jsonp_if_modified_since"); //jsonp If-Modified-Since variable
+static ngx_str_t  ngx_http_push_jsonp_if_none_match = ngx_string("push_jsonp_if_none_match"); //jsonp If-None-Match variable
+static char *ngx_http_push_jsonp(ngx_conf_t *cf, ngx_command_t *cmd, void *conf) {
+	ngx_http_push_loc_conf_t       *plcf = conf;
+
+	plcf->jsonp = 1;
+	plcf->jsonp_callback = ngx_http_get_variable_index(cf, &ngx_http_push_jsonp_callback);
+	plcf->jsonp_if_modified_since = ngx_http_get_variable_index(cf, &ngx_http_push_jsonp_if_modified_since);
+	plcf->jsonp_if_none_match = ngx_http_get_variable_index(cf, &ngx_http_push_jsonp_if_none_match);
+	if (plcf->jsonp_callback == NGX_ERROR) {
+		return NGX_CONF_ERROR;
+	}
+	return NGX_CONF_OK;
 }
 
 //great justice appears to be at hand
@@ -363,6 +379,13 @@ static ngx_command_t  ngx_http_push_commands[] = {
       offsetof(ngx_http_push_loc_conf_t, max_channel_id_length),
       NULL },
 	  
+	{ ngx_string("push_jsonp"),
+      NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_NOARGS,
+      ngx_http_push_jsonp,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      0,
+      NULL },
+
 	{ ngx_string("push_max_jsonp_callback_length"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_num_slot,


### PR DESCRIPTION
Among other better-to-have features, JSONP support is essential because NHPM isn't usable for a cross-domain environment such as Facebook application without it.
This patch aims to do nothing but JSONP support with less changes.