### PR TITLE
slight correction

### DIFF
--- a/src/ngx_http_push_module.c
+++ b/src/ngx_http_push_module.c
@@ -19,7 +19,6 @@ static void ngx_http_push_clean_timeouted_subscriber(ngx_event_t *ev)
 {
 	ngx_http_push_subscriber_t *subscriber = NULL;
 	ngx_http_request_t *r = NULL;
-	ngx_chain_t *chain = NULL;
 
 	subscriber = ev->data;
 	r = subscriber->request;
@@ -551,7 +550,7 @@ static ngx_int_t ngx_http_push_handle_subscriber_concurrency(ngx_http_request_t 
 			//in most reasonable cases, there'll be at most one subscriber on the
 			//channel. However, since settings are bound to locations and not
 			//specific channels, this assumption need not hold. Hence this broadcast.
-			ngx_int_t rc = ngx_http_push_broadcast_status_locked(channel, NGX_HTTP_NOT_FOUND, &NGX_HTTP_PUSH_HTTP_STATUS_409, r->connection->log, ngx_http_push_shpool);
+			ngx_http_push_broadcast_status_locked(channel, NGX_HTTP_NOT_FOUND, &NGX_HTTP_PUSH_HTTP_STATUS_409, r->connection->log, ngx_http_push_shpool);
 			ngx_shmtx_unlock(&ngx_http_push_shpool->mutex);
 
 			return NGX_OK;


### PR DESCRIPTION
Deleted a variable and an assignment that were not needed yet caused errors, because warnings are handled as errors
