### PR TITLE
Fix: detect Upgrade in multiple Connection values

### DIFF
--- a/src/nchan_module.c
+++ b/src/nchan_module.c
@@ -344,7 +344,7 @@ static ngx_int_t nchan_detect_websocket_handshake(ngx_http_request_t *r) {
   }
   
   if((tmp = nchan_get_header_value(r, NCHAN_HEADER_CONNECTION))) {
-    if(ngx_strncasecmp(tmp->data, NCHAN_UPGRADE.data, NCHAN_UPGRADE.len) != 0) return 0;
+    if(ngx_strcasestrn(tmp->data, NCHAN_UPGRADE.data, NCHAN_UPGRADE.len) == NULL) return 0;
   }
   else return 0;
   

--- a/src/nchan_module.c
+++ b/src/nchan_module.c
@@ -344,6 +344,7 @@ static ngx_int_t nchan_detect_websocket_handshake(ngx_http_request_t *r) {
   }
   
   if((tmp = nchan_get_header_value(r, NCHAN_HEADER_CONNECTION))) {
+    if(tmp->len < NCHAN_UPGRADE.len) return 0;
     if(ngx_strcasestrn(tmp->data, NCHAN_UPGRADE.data, NCHAN_UPGRADE.len) == NULL) return 0;
   }
   else return 0;


### PR DESCRIPTION
The prior code was expecting a exact header/value match for `Connection: Upgrade` to be able to upgrade the connection to websockets.

In my testing, Firefox 42.0, seems to send `Connection: keep-alive, Upgrade` which fails to then upgrade to a websocket connection.  This patch fixes that.