### PR TITLE
Omit duplicate response header Connection: Upgrade

### DIFF
--- a/src/subscribers/websocket.c
+++ b/src/subscribers/websocket.c
@@ -2,6 +2,7 @@
 #include <subscribers/common.h>
 #include <ngx_crypt.h>
 #include <ngx_sha1.h>
+#include <nginx.h>
 
 //#define DEBUG_LEVEL NGX_LOG_WARN
 #define DEBUG_LEVEL NGX_LOG_DEBUG
@@ -381,7 +382,9 @@ static void websocket_perform_handshake(full_subscriber_t *fsub) {
     
     nchan_add_response_header(r, &NCHAN_HEADER_SEC_WEBSOCKET_ACCEPT, &ws_accept_key);
     nchan_add_response_header(r, &NCHAN_HEADER_UPGRADE, &NCHAN_WEBSOCKET);
+#if nginx_version < 1003013
     nchan_add_response_header(r, &NCHAN_HEADER_CONNECTION, &NCHAN_UPGRADE);
+#endif
     r->headers_out.status_line = NCHAN_HTTP_STATUS_101;
     r->headers_out.status = NGX_HTTP_SWITCHING_PROTOCOLS;
 


### PR DESCRIPTION
Since Nginx 1.3.13, the `Connection: upgrade` response header is automatically appended when `r->headers_out.status == NGX_HTTP_SWITCHING_PROTOCOLS` (see https://github.com/nginx/nginx/commit/08a73b4aadebd9405ac52ec1f6eef5ca1fe8c11a).  

This pull request makes nchan omit adding (duplicating) the response header `Connection: Upgrade` after upgrading to a websocket connection since Nginx's header filter module will do it for us.