### PR TITLE
Fix: charset utf8 to utf-8

### DIFF
--- a/src/subscribers/eventsource.c
+++ b/src/subscribers/eventsource.c
@@ -27,7 +27,7 @@ static ngx_inline void ngx_init_set_membuf(ngx_buf_t *buf, u_char *start, u_char
 }
 
 static void es_ensure_headers_sent(full_subscriber_t *fsub) {
-  static const ngx_str_t   content_type = ngx_string("text/event-stream; charset=utf8");
+  static const ngx_str_t   content_type = ngx_string("text/event-stream; charset=utf-8");
   static const ngx_str_t   everything_ok = ngx_string("200 OK");
   static const ngx_str_t   hello = ngx_string(": hi\n\n");
   


### PR DESCRIPTION
Google Chrome and Safari complain about the charset=utf8 event-stream response and fail with this error in the console:
 `EventSource's response has a charset ("utf8") that is not UTF-8. Aborting the connection.`

This pull request corrects the charset to utf-8, which works well with all browsers I've tested (Firefox, Chrome and Safari -- all on OS X 10.11)