### PR TITLE
Fix hiredis linking issue

### DIFF
--- a/config
+++ b/config
@@ -18,7 +18,6 @@ if [ $ngx_found = no ]; then
   ngx_feature_libs=""
 else
   _NCHAN_HIREDIS_SRCS=""
-  CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
 fi
 
 
@@ -91,14 +90,17 @@ if [ $ngx_module_link = DYNAMIC ] ; then
   ngx_module_type=HTTP
   ngx_module_name=nchan_module
   ngx_module_srcs="$_NCHAN_SRCS"
+  ngx_module_libs=$ngx_feature_libs
   . auto/module
 elif [ $ngx_module_link = ADDON ] ; then
   ngx_module_type=HTTP
   ngx_module_name=nchan_module
+  ngx_module_libs=$ngx_feature_libs
   ngx_module_srcs="$_NCHAN_SRCS"
   . auto/module
 else
   NGX_ADDON_SRCS="$NGX_ADDON_SRCS $_NCHAN_SRCS"
+  CORE_LIBS="$CORE_LIBS $ngx_feature_libs"
   CORE_INCS="$CORE_INCS $ngx_module_incs"
   HTTP_MODULES="$HTTP_MODULES nchan_module"
 fi


### PR DESCRIPTION
When nchan is built as a dynamic module and a system hiredis is found,
hiredis should be linked to the .so file and not the nginx binary.

So, CORE_LIBS should be altered only on non-dynamic builds, on dynamic
builds ngx_module_libs should be used.