### PR TITLE
Fix maybe-uninitialized error

### DIFF
--- a/src/store/redis/cluster.c
+++ b/src/store/redis/cluster.c
@@ -774,7 +774,7 @@ static void redis_get_cluster_nodes_callback(redisAsyncContext *ac, void *rep, v
   redis_cluster_t               *cluster = NULL;
   ngx_uint_t                     num_master_nodes = 0;
   uint32_t                       homebrew_cluster_id = 0;
-  int                            configured_unverified_nodes;
+  int                            configured_unverified_nodes = 0;
   
   nchan_list_t                   unassociated_nodes;
   nchan_list_el_t               *cur;


### PR DESCRIPTION
```
cc -c -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g  -DNDK_SET_VAR  -I src/core -I src/event -I src/event/modules -I src/os/unix -I /tmp/src/lua-nginx-module-0.10.2/src/api -I objs -I src/http -I src/http/modules -I src/http/v2 -I /app/nchan/src -I /usr/include/luajit-2.0 \
        -o objs/addon/redis/cluster.o \
        /app/nchan/src/store/redis/cluster.c
/app/nchan/src/store/redis/cluster.c: In function 'redis_get_cluster_nodes_callback':
/app/nchan/src/store/redis/cluster.c:603:37: error: 'configured_unverified_nodes' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   cluster->node_connections_pending = configured_unverified_nodes;
                                     ^
/app/nchan/src/store/redis/cluster.c:777:34: note: 'configured_unverified_nodes' was declared here
   int                            configured_unverified_nodes;
                                  ^
cc1: all warnings being treated as errors
objs/Makefile:1751: recipe for target 'objs/addon/redis/cluster.o' failed
```

Not sure if this is the correct way to fix it.