### PR TITLE
Fix an issue when polling from redis for the first time and the tag o…

### DIFF
--- a/src/store/memory/memstore.c
+++ b/src/store/memory/memstore.c
@@ -2398,12 +2398,10 @@ static ngx_int_t chanhead_push_message(memstore_channel_head_t *ch, store_messag
   //set time and tag
   if(msg->msg->id.time == 0) {
     msg->msg->id.time = ngx_time();
+    msg->msg->id.tag.fixed[0] = 0;
   }
   if(ch->msg_last && ch->msg_last->msg->id.time == msg->msg->id.time) {
     msg->msg->id.tag.fixed[0] = ch->msg_last->msg->id.tag.fixed[0] + 1;
-  }
-  else {
-    msg->msg->id.tag.fixed[0] = 0;
   }
 
   if(ch->msg_first == NULL) {


### PR DESCRIPTION
…f first message in the redis queue is not 0, it always become 0 in the memory queue

Hope the commit message describe it clearly. ;)

Basically when the first message in the redis queue with a non-zero tag, for example
`11111:123`
When a New Nchan restarts and connected to this redis and starts to poll, the message will be served as `11111:0`.

