### PR TITLE
Remove max subscriber checks on redis

### DIFF
--- a/src/store/memory/memstore.c
+++ b/src/store/memory/memstore.c
@@ -1962,11 +1962,8 @@ static ngx_int_t redis_subscribe_channel_authcheck_callback(ngx_int_t status, vo
     if(channel == NULL) {
       channel_status = cf->subscribe_only_existing_channel ? SUB_CHANNEL_UNAUTHORIZED : SUB_CHANNEL_AUTHORIZED;
     }
-    else if(cf->max_channel_subscribers == 0) {
-      channel_status = SUB_CHANNEL_AUTHORIZED;
-    }
     else {
-      channel_status = channel->subscribers >= cf->max_channel_subscribers ? SUB_CHANNEL_UNAUTHORIZED : SUB_CHANNEL_AUTHORIZED;
+      channel_status = SUB_CHANNEL_AUTHORIZED;
     }
     nchan_store_subscribe_continued(channel_status, NULL, data);
   }


### PR DESCRIPTION
Hey, this is trying to solve #265 . Let me know if this is not the correct way to solve it.

I think the max number of subscriber is guarded on memstore level always, so we might not need it on redisstore level.