### PR TITLE
Fix an bug where only pass in If-Modified-Since header cause Nchan wo…

### DIFF
--- a/src/nchan_types.h
+++ b/src/nchan_types.h
@@ -60,8 +60,8 @@ union nchan_msg_multitag {
 typedef struct {
   time_t                          time; //tag message by time
   union nchan_msg_multitag        tag;
-  unsigned                        tagactive:16;
-  unsigned                        tagcount:16;
+  int16_t                         tagactive;
+  int16_t                         tagcount;
 } nchan_msg_id_t;
 
 typedef struct {

--- a/src/store/memory/memstore.c
+++ b/src/store/memory/memstore.c
@@ -2493,8 +2493,6 @@ static ngx_int_t nchan_store_async_get_multi_message(ngx_str_t *chid, nchan_msg_
   }
   
   //DBG("get multi msg %V (count: %i)", msgid_to_str(msg_id), n);
-  
-  
   if(msg_id->time == 0) {
     for(i = 0; i < n; i++) {
       assert(nchan_extract_from_multi_msgid(msg_id, i, &req_msgid[i]) == NGX_OK);


### PR DESCRIPTION
…rker to crash on multi-channel

## Issue
Nchan worker crashed with following error when only "If-Modified-Since" header is passed in with a multi-channel request.
```
192.168.99.1 - - - [19/Dec/2016:04:21:17 +0000] "GET /sub/multi/1,2,3 HTTP/1.1" 204 38 "-" "curl/7.51.0" 0.905
2016/12/19 04:21:21 [error] 749#0: NCHAN MSG_ID:can't extract msgid 2 from multi-msg of count 1
Assertion failed: nchan_extract_from_multi_msgid(msg_id, i, &req_msgid[i]) == NGX_OK (/app/nchan/src/store/memory/memstore.c: nchan_store_async_get_multi_message: 2509)
2016/12/19 04:21:21 [alert] 747#0: worker process 749 exited on signal 6
```

## Causes
When we requesting a multichannel with "If-Modified-Since" header only (withou out "If-None-Match" header), it creates a `msgid` with only 1 tag. In this case, it won't match the multi-channel tag count, thus the error.

## Possible fix
This fix handles this situation more gracefully, where it will fulfill the tags with `-1` to the number of tags the multi-channel required.

## Highlights / Notes
```
 typedef struct {
   time_t                          time; //tag message by time
   union nchan_msg_multitag        tag;
-  unsigned                        tagactive:16;
-  unsigned                        tagcount:16;
+  int16_t                         tagactive;
+  int16_t                         tagcount;
 } nchan_msg_id_t;
```
I allow `tagactive` to be `-1` which means no tag is in active. Also, both `fixed` and `allocd` are `int16_t`, so I reckon it's ok to make `tagactive` and `tagcount` to be `int16_t` too.



Let me know what you think.
Cheers
