### PR TITLE
adding `keep_alive_interval` option to longpoll

### DIFF
--- a/src/nchan_commands.rb
+++ b/src/nchan_commands.rb
@@ -1,3 +1,4 @@
+
 CfCmd.new do
   
   nchan_channel_id [:srv, :loc, :if],
@@ -155,6 +156,18 @@ CfCmd.new do
       value: "<string>",
       default: "\\n",
       info: "Message separator string for the http-raw-stream subscriber. Automatically terminated with a newline character."
+
+  nchan_subscriber_keep_alive_string [:srv, :loc, :if],
+      :ngx_conf_set_str_slot,
+      [:loc_conf, :subscriber_keep_alive_string],
+      args: 1,
+
+      group: "pubsub",
+      tags: ['subscriber'],
+      value: "<string>",
+      default: ".",
+      info: "Message separator string for the http-raw-stream subscriber. Automatically terminated with a newline character."
+
   
   nchan_subscriber_first_message [:srv, :loc, :if],
       :nchan_subscriber_first_message_directive,
@@ -179,6 +192,17 @@ CfCmd.new do
   #    - broadcast: any number of concurrent subscriber requests may be held.
   #    - last: only the most recent subscriber request is kept, all others get a 409 Conflict response.
   #    - first: only the oldest subscriber request is kept, all others get a 409 Conflict response."
+
+  nchan_subscriber_keep_alive_interval [:srv, :loc, :if],
+      :ngx_conf_set_sec_slot,
+      [:loc_conf, :subscriber_keep_alive_interval],
+
+      group: "pubsub",
+      tags: ['subscriber'],
+      value: "<number> (seconds)",
+      default: "0 (none)",
+      info: "Interval for sending keep alive strings. Disabled by default."
+
   
   nchan_websocket_ping_interval [:srv, :loc, :if],
       :ngx_conf_set_sec_slot,

--- a/src/nchan_config_commands.c
+++ b/src/nchan_config_commands.c
@@ -127,11 +127,25 @@ static ngx_command_t  nchan_commands[] = {
     offsetof(nchan_loc_conf_t, subscriber_http_raw_stream_separator),
     NULL } ,
 
+  { ngx_string("nchan_subscriber_keep_alive_string"),
+    NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
+    ngx_conf_set_str_slot,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    offsetof(nchan_loc_conf_t, subscriber_keep_alive_string),
+    NULL } ,
+
   { ngx_string("nchan_subscriber_first_message"),
     NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
     nchan_subscriber_first_message_directive,
     NGX_HTTP_LOC_CONF_OFFSET,
     0,
+    NULL } ,
+
+  { ngx_string("nchan_subscriber_keep_alive_interval"),
+    NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_HTTP_LIF_CONF|NGX_CONF_TAKE1,
+    ngx_conf_set_sec_slot,
+    NGX_HTTP_LOC_CONF_OFFSET,
+    offsetof(nchan_loc_conf_t, subscriber_keep_alive_interval),
     NULL } ,
 
   { ngx_string("nchan_websocket_ping_interval"),

--- a/src/nchan_defs.h
+++ b/src/nchan_defs.h
@@ -7,6 +7,7 @@
 #define NCHAN_DEFAULT_SUBSCRIBER_TIMEOUT 0  //default: never timeout
 //(liucougar: this is a bit confusing, but it is what's the default behavior before this option is introducecd)
 #define NCHAN_DEFAULT_WEBSOCKET_PING_INTERVAL 0
+#define NCHAN_DEFAULT_SUBSCRIBER_DEFAULT_KEEP_ALIVE_INTERVAL 0
 
 #define NCHAN_DEFAULT_CHANNEL_TIMEOUT 5 //default: timeout in 5 seconds
 

--- a/src/nchan_setup.c
+++ b/src/nchan_setup.c
@@ -102,6 +102,7 @@ static void *nchan_create_loc_conf(ngx_conf_t *cf) {
   lcf->subscriber_first_message=NCHAN_SUBSCRIBER_FIRST_MESSAGE_UNSET;
   
   lcf->subscriber_timeout=NGX_CONF_UNSET;
+  lcf->subscriber_keep_alive_interval=NGX_CONF_UNSET;
   lcf->subscribe_only_existing_channel=NGX_CONF_UNSET;
   lcf->redis_idle_channel_cache_timeout=NGX_CONF_UNSET;
   lcf->max_channel_id_length=NGX_CONF_UNSET;
@@ -246,7 +247,8 @@ static char * nchan_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child) {
   if (conf->subscriber_first_message == NCHAN_SUBSCRIBER_FIRST_MESSAGE_UNSET) {
     conf->subscriber_first_message = (prev->subscriber_first_message == NCHAN_SUBSCRIBER_FIRST_MESSAGE_UNSET) ? NCHAN_SUBSCRIBER_DEFAULT_FIRST_MESSAGE : prev->subscriber_first_message;
   }
-  
+
+  ngx_conf_merge_sec_value(conf->subscriber_keep_alive_interval, prev->subscriber_keep_alive_interval, NCHAN_DEFAULT_SUBSCRIBER_DEFAULT_KEEP_ALIVE_INTERVAL);
   ngx_conf_merge_sec_value(conf->websocket_ping_interval, prev->websocket_ping_interval, NCHAN_DEFAULT_WEBSOCKET_PING_INTERVAL);
   
   ngx_conf_merge_sec_value(conf->subscriber_timeout, prev->subscriber_timeout, NCHAN_DEFAULT_SUBSCRIBER_TIMEOUT);
@@ -258,7 +260,8 @@ static char * nchan_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child) {
   ngx_conf_merge_value(conf->channel_timeout, prev->channel_timeout, NCHAN_DEFAULT_CHANNEL_TIMEOUT);
   
   ngx_conf_merge_str_value(conf->subscriber_http_raw_stream_separator, prev->subscriber_http_raw_stream_separator, "\n");
-  
+  ngx_conf_merge_str_value(conf->subscriber_keep_alive_string, prev->subscriber_keep_alive_string, ".");
+
   ngx_conf_merge_str_value(conf->channel_id_split_delimiter, prev->channel_id_split_delimiter, "");
   MERGE_CONF(conf, prev, allow_origin);
   ngx_conf_merge_str_value(conf->eventsource_event, prev->eventsource_event, "");

--- a/src/nchan_types.h
+++ b/src/nchan_types.h
@@ -281,7 +281,10 @@ struct nchan_loc_conf_s { //nchan_loc_conf_t
   nchan_conf_group_t              group;
   
   time_t                          subscriber_timeout;
-  
+
+  time_t                          subscriber_keep_alive_interval;
+  ngx_str_t                       subscriber_keep_alive_string;
+
   ngx_int_t                       longpoll_multimsg;
   ngx_int_t                       longpoll_multimsg_use_raw_stream_separator;
   

--- a/src/subscribers/longpoll-private.h
+++ b/src/subscribers/longpoll-private.h
@@ -9,6 +9,7 @@ typedef struct {
   subscriber_callback_pt  dequeue_handler;
   void                   *dequeue_handler_data;
   ngx_event_t             timeout_ev;
+  ngx_event_t             keep_alive_ev;
   
   nchan_longpoll_multimsg_t *multimsg_first;
   nchan_longpoll_multimsg_t *multimsg_last;

--- a/src/subscribers/longpoll.c
+++ b/src/subscribers/longpoll.c
@@ -4,6 +4,10 @@
 #define DEBUG_LEVEL NGX_LOG_DEBUG
 #define DBG(fmt, arg...) ngx_log_error(DEBUG_LEVEL, ngx_cycle->log, 0, "SUB:LONGPOLL:" fmt, ##arg)
 #define ERR(fmt, arg...) ngx_log_error(NGX_LOG_ERR, ngx_cycle->log, 0, "SUB:LONGPOLL:" fmt, ##arg)
+
+#define REQUEST_PCALLOC(r, what) what = ngx_pcalloc((r)->pool, sizeof(*(what)))
+#define REQUEST_PALLOC(r, what) what = ngx_palloc((r)->pool, sizeof(*(what)))
+
 #include <assert.h>
 #include "longpoll-private.h"
 
@@ -15,6 +19,8 @@ void memstore_fakeprocess_pop(void);
 ngx_int_t memstore_slot(void);
 
 static const subscriber_t new_longpoll_sub;
+
+static void keep_alive_handler(ngx_event_t *ev);
 
 static void empty_handler() { }
 
@@ -52,7 +58,8 @@ subscriber_t *longpoll_subscriber_create(ngx_http_request_t *r, nchan_msg_id_t *
   fsub->data.finalize_request = 1;
   fsub->data.holding = 0;
   fsub->data.act_as_intervalpoll = 0;
-  
+
+  ngx_memzero(&fsub->data.keep_alive_ev, sizeof(fsub->data.keep_alive_ev));
   nchan_subscriber_init_timeout_timer(&fsub->sub, &fsub->data.timeout_ev);
   
   fsub->data.dequeue_handler = empty_handler;
@@ -98,6 +105,10 @@ ngx_int_t longpoll_subscriber_destroy(subscriber_t *sub) {
   }
   else {
     DBG("%p destroy for req %p", sub, fsub->sub.request);
+    if(fsub->data.keep_alive_ev.timer_set) {
+        ngx_del_timer(&fsub->data.keep_alive_ev);
+    }
+
     nchan_free_msg_id(&fsub->sub.last_msgid);
     assert(sub->status == DEAD);
 #if NCHAN_SUBSCRIBER_LEAK_DEBUG
@@ -149,6 +160,12 @@ ngx_int_t longpoll_enqueue(subscriber_t *self) {
   
   fsub->sub.enqueued = 1;
   ensure_request_hold(fsub);
+
+  if(self->cf->subscriber_keep_alive_interval > 0) {
+    nchan_init_timer(&fsub->data.keep_alive_ev, keep_alive_handler, fsub);
+    ngx_add_timer(&fsub->data.keep_alive_ev, self->cf->subscriber_keep_alive_interval * 1000);
+  }
+
   if(self->cf->subscriber_timeout > 0) {
     //add timeout timer
     ngx_add_timer(&fsub->data.timeout_ev, self->cf->subscriber_timeout * 1000);
@@ -456,6 +473,8 @@ static ngx_int_t longpoll_multipart_respond(full_subscriber_t *fsub) {
   
   
   return NGX_OK;
+
+
 }
 
 static ngx_int_t longpoll_respond_status(subscriber_t *self, ngx_int_t status_code, const ngx_str_t *status_line) {
@@ -523,6 +542,42 @@ static void request_cleanup_handler(subscriber_t *sub) {
 
 }
 
+
+static void keep_alive_handler(ngx_event_t *ev) {
+  full_subscriber_t *fsub = (full_subscriber_t *)ev->data;
+
+  if(ev->timedout) {
+    ngx_buf_t   *buf = REQUEST_PCALLOC(fsub->sub.request, buf);
+    ngx_chain_t *chain = REQUEST_PALLOC(fsub->sub.request, chain);
+    nchan_loc_conf_t       *cf = ngx_http_get_module_loc_conf(fsub->sub.request, ngx_nchan_module);
+    size_t                  separator_len = cf->subscriber_keep_alive_string.len;
+
+    ev->timedout=0;
+    ngx_add_timer(&fsub->data.keep_alive_ev, fsub->sub.cf->subscriber_keep_alive_interval * 1000);
+
+    chain->buf=buf;
+    chain->next=NULL;
+
+    buf = chain->buf;
+    ngx_memzero(buf, sizeof(ngx_buf_t));
+    buf->start = cf->subscriber_keep_alive_string.data;
+    buf->pos = buf->start;
+    buf->end = buf->start + separator_len;
+    buf->last = buf->end;
+
+    buf->last_in_chain = 1;
+    buf->memory = 1;
+    buf->last_buf = 1;
+    buf->flush = 1;
+
+    if(!fsub->data.shook_hands) {
+      nchan_cleverly_output_headers_only_for_later_response(fsub->sub.request);
+      fsub->data.shook_hands = 1;
+    }
+
+    nchan_output_filter(fsub->sub.request, chain);
+  }
+}
 
 static ngx_int_t longpoll_set_dequeue_callback(subscriber_t *self, subscriber_callback_pt cb, void *privdata) {
   full_subscriber_t  *fsub = (full_subscriber_t  *)self;


### PR DESCRIPTION
I've copied most of th code from raw-http-stream.c, but in general I would like an option to send keep alive also on longpoll subscribers. (similar to websocket ping)

also for some reason it's always sending \n togother with the separator. can't figure out how to remove it.