### PR TITLE
do not refuse websocket frames with binary opcode set

### DIFF
--- a/src/subscribers/websocket.c
+++ b/src/subscribers/websocket.c
@@ -1187,7 +1187,7 @@ static void websocket_reading(ngx_http_request_t *r) {
         break;
       
       case WEBSOCKET_READ_GET_PAYLOAD_STEP:
-        if ((frame->opcode != WEBSOCKET_OPCODE_TEXT) && (frame->opcode != WEBSOCKET_OPCODE_CLOSE) && (frame->opcode != WEBSOCKET_OPCODE_PING) && (frame->opcode != WEBSOCKET_OPCODE_PONG)) {
+        if ((frame->opcode != WEBSOCKET_OPCODE_TEXT) && (frame->opcode != WEBSOCKET_OPCODE_BINARY) && (frame->opcode != WEBSOCKET_OPCODE_CLOSE) && (frame->opcode != WEBSOCKET_OPCODE_PING) && (frame->opcode != WEBSOCKET_OPCODE_PONG)) {
           websocket_send_frame(fsub, WEBSOCKET_CLOSE_LAST_FRAME_BYTE, 0, NULL);
           return websocket_reading_finalize(r, temp_pool);
         }


### PR DESCRIPTION
When publisher sends message using WebSocket  connection with binary opcode set it is immediately dropped, After this fix all looks ok.