### PR TITLE
Make Nchan work with lua-nginx-module: Nchan causes a build error

### DIFF
--- a/config
+++ b/config
@@ -88,8 +88,7 @@ _NCHAN_UTIL_SRCS=" \
 ngx_feature="memrchr()"
 ngx_feature_run=yes
 ngx_feature_incs=" \
-  #include <string.h> 
-  #include <stddef.h> 
+  #include <stddef.h>
 "
 ngx_feature_test=" \
   const char *str = \"aboobar\"; \
@@ -98,7 +97,7 @@ ngx_feature_test=" \
   if(place != found) { return 1; } \
 "
 . auto/feature
- 
+
 if [ $ngx_found = no ]; then
   _NCHAN_UTIL_SRCS="$_NCHAN_UTIL_SRCS  $_nchan_util_dir/memrchr.c"
 fi

--- a/src/util/memrchr.h
+++ b/src/util/memrchr.h
@@ -1,6 +1,5 @@
 #ifndef NCHAN_MEMRCHR_H
 #define NCHAN_MEMRCHR_H
-#include <string.h>
 #include <stddef.h>
 
 void *memrchr(const void *s, int c, size_t n);


### PR DESCRIPTION
*(Hi Leo! The text below is from the commit message. Nginx 1.15.2 b.t.w.)*

Remove `#include <string.h>`. It's not needed (only stddef.h needed) and
results in this error, when building lua-nginx-module: (namely that
malloc_trim disappears, but lua-nginx-module needs it)

```
... really many lines ...
cc -c -I/opt/luajit/include/luajit-2.1  -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g  -DNDK_SET_VAR  -I src/core -I src/event -I src/event/modules -I src/os/unix -I /tmp/nginx-modules/ngx_devel_kit/objs -I objs/addon/ndk -I /tmp/nginx-modules/lua-nginx-module/src/api -I objs -I src/http -I src/http/modules -I src/http/v2 -I /tmp/nginx-modules/ngx_devel_kit/src -I /tmp/nginx-modules/ngx_devel_kit/src -I /tmp/nginx-modules/ngx_devel_kit/objs -I objs/addon/ndk -I /opt/luajit/include/luajit-2.1 -I /tmp/nginx-modules/nchan/src -I src/stream \
	-o objs/addon/src/ngx_http_lua_coroutine.o \
	/tmp/nginx-modules/lua-nginx-module/src/ngx_http_lua_coroutine.c
cc -c -I/opt/luajit/include/luajit-2.1  -pipe  -O -W -Wall -Wpointer-arith -Wno-unused-parameter -Werror -g  -DNDK_SET_VAR  -I src/core -I src/event -I src/event/modules -I src/os/unix -I /tmp/nginx-modules/ngx_devel_kit/objs -I objs/addon/ndk -I /tmp/nginx-modules/lua-nginx-module/src/api -I objs -I src/http -I src/http/modules -I src/http/v2 -I /tmp/nginx-modules/ngx_devel_kit/src -I /tmp/nginx-modules/ngx_devel_kit/src -I /tmp/nginx-modules/ngx_devel_kit/objs -I objs/addon/ndk -I /opt/luajit/include/luajit-2.1 -I /tmp/nginx-modules/nchan/src -I src/stream \
	-o objs/addon/src/ngx_http_lua_bodyfilterby.o \
	/tmp/nginx-modules/lua-nginx-module/src/ngx_http_lua_bodyfilterby.c
In file included from src/core/ngx_core.h:59:0,
                 from /tmp/nginx-modules/lua-nginx-module/src/ddebug.h:13,
                 from /tmp/nginx-modules/lua-nginx-module/src/ngx_http_lua_logby.c:10:
/tmp/nginx-modules/lua-nginx-module/src/ngx_http_lua_logby.c: In function 'ngx_http_lua_log_handler':
/tmp/nginx-modules/lua-nginx-module/src/ngx_http_lua_logby.c:96:58: error: implicit declaration of function 'malloc_trim' [-Werror=implicit-function-declaration]
                            "malloc_trim(1) returned %d", malloc_trim(1));
                                                          ^
src/core/ngx_log.h:93:48: note: in definition of macro 'ngx_log_debug'
         ngx_log_error_core(NGX_LOG_DEBUG, log, __VA_ARGS__)
                                                ^~~~~~~~~~~
/tmp/nginx-modules/lua-nginx-module/src/ngx_http_lua_logby.c:95:13: note: in expansion of macro 'ngx_log_debug1'
             ngx_log_debug1(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
             ^~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [objs/Makefile:2051: objs/addon/src/ngx_http_lua_logby.o] Error 1
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/usr/src/nginx-1.15.2'
make: *** [Makefile:8: build] Error 2

```

Somehow, including  string.h in Nchan makes malloc_trim disappear. And
lua-nginx-module needs malloc_trim, and the build (of lua-nginx-module)
then fails.

I'm assuming  string.h  somehow includes a [malloc.h file or related
file] that does *not* have  malloc_trim.  And the files that otherwise
gets included, when  string.h  isn't used in Nchan — they do
somewhere include  malloc_trim.

This Nchan + lua-nginx-module compilation error was introduced in
this revision:

e023c63 fix: memrchr() is non-POSIX, check for it on configure

Which added memrchr, if missing — but also accidentally includes string.h.

With this remove-string.h-tiny-patch, for both that old revision
e023c63, and the new v1.2.0, lua-nginx-module builds okay, no error.