### PR TITLE
Fix possible memory corruption with upstream requests

### DIFF
--- a/src/subscribers/websocket.c
+++ b/src/subscribers/websocket.c
@@ -671,10 +671,10 @@ static ngx_int_t websocket_publish(full_subscriber_t *fsub, ngx_buf_t *buf, int 
   //move the msg pool
   d->pool = fsub->publisher.msg_pool;
   d->msgbuf = buf;
+  d->subrequest = NULL;
   fsub->publisher.msg_pool = NULL;
   
   if(fsub->publisher.intercept || fsub->publisher.upstream_request_url == NULL) { // don't need to send request upstream
-    d->subrequest = NULL;
     websocket_publish_continue(d);
   }
   else {


### PR DESCRIPTION
There are several possible configuration scenarios where using `nchan_publisher_upstream_request` can cause memory corruption and undefined behavior. This is due to sanity checks being performed (and wrongly succeeding) on a variable which is never assigned.

### Example
Consider this stack trace:
![stack](https://user-images.githubusercontent.com/58403851/97797929-5a3ccd80-1bef-11eb-910d-6908db3af673.PNG)

`At frame 6:`
The `ws_publish_data_t` struct is allocated here without clearing memory (line 662).
Thus, `(ws_publish_data_t)->subrequest` refers to an undefined memory location (line 690).
It is to be assigned here after the subrequest setup is complete, and not referenced upon until then.
This is normally the case, as the subrequest gets 'queued' and we go all the way back down to frame `2` before the subrequest is actually executed and finalized.

`At frame 13:`
However, if for whatever reason subrequest setup fails, nginx finalizes the subrequest early.
For instance, here the setup fails because the request is too large (line 989).

`At frame 15:`
Since the request is being finalized, NChan subrequest handler gets called, expecting the upstream subrequest to have been successfully queued and `(ws_publish_data_t)->subrequest` assigned.
But we're still in the same event that will only assign `(ws_publish_data_t)->subrequest` once we get back down to frame `6`.

`At frame 16:`
A sanity check assertion (line 575) can wrongly succeed here due to `(ws_publish_data_t)->subrequest` having an undefined value.
Thus, past this check we can get undefined behavior and memory corruption.

`At frame 17:`
We'll most likely segfault here from trying to dereference `(ws_publish_data_t)->subrequest`, but we can also corrupt memory and/or cause some other undefined behavior instead!

### Fix
Clear `(ws_publish_data_t)->subrequest` right after the creating the `ws_publish_data_t` structure, so that various further sanity checks will correctly interrupt execution on error.

### Note
This is part of a series of patches to resolve [issue #588](https://github.com/slact/nchan/issues/588).