### PR TITLE
Fix #633 Recent nginx changes cause build errors

### DIFF
--- a/src/util/hdr_histogram.c
+++ b/src/util/hdr_histogram.c
@@ -4,6 +4,10 @@
  * as explained at http://creativecommons.org/publicdomain/zero/1.0/
  */
 
+#include <nchan_module.h>
+#include <util/shmem.h>
+#include <store/memory/store.h>
+
 #include <math.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -13,10 +17,6 @@
 #include <stdint.h>
 #include <errno.h>
 #include <inttypes.h>
-
-#include <nchan_module.h>
-#include <util/shmem.h>
-#include <store/memory/store.h>
 
 #include "hdr_histogram.h"
 


### PR DESCRIPTION
RE: #633 
So the nginx devs pointed me in the right direction: The issue is caused by modules including system headers prior to nginx ones. In this particular case, it leads to undefined GNU_SOURCE macro and thus missing type declaration.

Simply re-arranging the imports in hdr_histogram.c fixes the issue.