### PR TITLE
Reorder includes to fix compilation

### DIFF
--- a/src/util/nchan_accumulator.c
+++ b/src/util/nchan_accumulator.c
@@ -1,5 +1,5 @@
-#include <math.h>
 #include <nchan_module.h>
+#include <math.h>
 
 #include "nchan_accumulator.h"
 


### PR DESCRIPTION
Mainline NGINX 1.23.2 fails to compile with:

```
In file included from src/event/ngx_event.h:526,
                 from src/http/ngx_http_upstream.h:14,
                 from src/http/ngx_http.h:34,
                 from ./nchan/src/nchan_module.h:17,
                 from ./nchan/src/util/nchan_accumulator.c:2:
src/event/ngx_event_udp.h:38:27: error: field ‘pkt6’ has incomplete type
     struct in6_pktinfo    pkt6;
                           ^~~~
```

Because it wants NGINX includes go before the system ones.

This reorders it correctly so that the compilation goes through fine.