### PR TITLE
make sure nginx #include statements appear at the beginning

### DIFF
--- a/src/nchan_module.h
+++ b/src/nchan_module.h
@@ -13,8 +13,10 @@
 //#define ONE_FAKE_CHANNEL_OWNER 2
 #define MAX_FAKE_WORKERS 5
 #endif
-#include <nchan_version.h>
+#include <ngx_config.h>
+#include <ngx_core.h>
 #include <ngx_http.h>
+#include <nchan_version.h>
 
 //building for old versions
 #ifndef NGX_MAX_INT_T_VALUE


### PR DESCRIPTION
the documentation specifies that <ngx_config.h> <ngx_core.h> must be included, and before any other (system) include files.

http://nginx.org/en/docs/dev/development_guide.html#include_files

this fixes at least one compile issue with nginx 1.23
fixes #655 