### PR TITLE
Fix function pointer type mismatches for GCC 15 compatibility

### DIFF
--- a/src/store/memory/memstore.c
+++ b/src/store/memory/memstore.c
@@ -1394,7 +1394,7 @@ ngx_int_t nchan_memstore_publish_generic(memstore_channel_head_t *head, nchan_ms
 
 static ngx_int_t chanhead_messages_delete(memstore_channel_head_t *ch);
 
-static ngx_int_t empty_callback(){
+static ngx_int_t empty_callback(ngx_int_t status, void *ptr1, void *ptr2){
   return NGX_OK;
 }
 

--- a/src/subscribers/eventsource.c
+++ b/src/subscribers/eventsource.c
@@ -244,7 +244,7 @@ static ngx_int_t es_respond_message(subscriber_t *sub,  nchan_msg_t *msg) {
   return nchan_output_msg_filter(fsub->sub.request, msg, first_link);
 }
 
-static void empty_handler(void) {}
+static void empty_cleanup_handler(void *data) {}
 
 static ngx_int_t es_respond_status(subscriber_t *sub, ngx_int_t status_code, const ngx_str_t *status_line,  ngx_chain_t *status_body){
   
@@ -275,7 +275,7 @@ static ngx_int_t es_respond_status(subscriber_t *sub, ngx_int_t status_code, con
   nchan_output_filter(fsub->sub.request, &bc.chain);
   
   if((status_code >=400 && status_code <599) || status_code == NGX_HTTP_NOT_MODIFIED) {
-    fsub->data.cln->handler = (ngx_http_cleanup_pt )empty_handler;
+    fsub->data.cln->handler = empty_cleanup_handler;
     fsub->sub.request->keepalive=0;
     sub->request->headers_out.status = status_code;
     fsub->data.finalize_request=1;

--- a/src/subscribers/longpoll.c
+++ b/src/subscribers/longpoll.c
@@ -17,7 +17,8 @@ ngx_int_t memstore_slot(void);
 
 static const subscriber_t new_longpoll_sub;
 
-static void empty_handler() { }
+static void empty_subscriber_handler(subscriber_t *sub, void *data) { }
+static void empty_cleanup_handler(void *data) { }
 
 static void sudden_abort_handler(subscriber_t *sub) {
   if(sub->request && sub->status != DEAD) {
@@ -56,10 +57,10 @@ subscriber_t *longpoll_subscriber_create(ngx_http_request_t *r, nchan_msg_id_t *
   
   nchan_subscriber_init_timeout_timer(&fsub->sub, &fsub->data.timeout_ev);
   
-  fsub->data.enqueue_callback = empty_handler;
+  fsub->data.enqueue_callback = empty_subscriber_handler;
   fsub->data.enqueue_callback_data = NULL;
   
-  fsub->data.dequeue_callback = empty_handler;
+  fsub->data.dequeue_callback = empty_subscriber_handler;
   fsub->data.dequeue_callback_data = NULL;
   
   fsub->data.already_responded = 0;
@@ -296,7 +297,7 @@ static ngx_int_t longpoll_respond_message(subscriber_t *self, nchan_msg_t *msg) 
   }
   if(!cf->longpoll_multimsg) {
     //disable abort handler
-    fsub->data.cln->handler = empty_handler;
+    fsub->data.cln->handler = empty_cleanup_handler;
     
     assert(fsub->data.already_responded != 1);
     fsub->data.already_responded = 1;
@@ -344,7 +345,7 @@ static ngx_int_t longpoll_multipart_respond(full_subscriber_t *fsub) {
   nchan_longpoll_multimsg_t *first, *cur;
   
   //disable abort handler
-  fsub->data.cln->handler = empty_handler;
+  fsub->data.cln->handler = empty_cleanup_handler;
   
   first = fsub->data.multimsg_first;
   
@@ -457,7 +458,7 @@ static ngx_int_t longpoll_respond_status(subscriber_t *self, ngx_int_t status_co
   nchan_set_msgid_http_response_headers(r, NULL, &self->last_msgid);
   
   //disable abort handler
-  fsub->data.cln->handler = empty_handler;
+  fsub->data.cln->handler = empty_cleanup_handler;
   
   nchan_respond_status(r, status_code, status_line, status_body, 0);
 
@@ -470,7 +471,7 @@ ngx_int_t subscriber_respond_unqueued_status(full_subscriber_t *fsub, ngx_int_t 
   nchan_loc_conf_t       *cf = fsub->sub.cf;
   nchan_request_ctx_t    *ctx;
   
-  fsub->data.cln->handler = (ngx_http_cleanup_pt )empty_handler;
+  fsub->data.cln->handler = empty_cleanup_handler;
   fsub->data.finalize_request = 0;
   fsub->sub.status = DEAD;
   fsub->sub.fn->dequeue(&fsub->sub);
@@ -483,7 +484,7 @@ ngx_int_t subscriber_respond_unqueued_status(full_subscriber_t *fsub, ngx_int_t 
 
 void subscriber_maybe_dequeue_after_status_response(full_subscriber_t *fsub, ngx_int_t status_code) {
   if((status_code >=400 && status_code < 600) || status_code == NGX_HTTP_NOT_MODIFIED) {
-    fsub->data.cln->handler = (ngx_http_cleanup_pt )empty_handler;
+    fsub->data.cln->handler = empty_cleanup_handler;
     fsub->sub.request->keepalive=0;
     fsub->data.finalize_request=1;
     fsub->sub.request->headers_out.status = status_code;

--- a/src/subscribers/memstore_ipc.c
+++ b/src/subscribers/memstore_ipc.c
@@ -26,7 +26,7 @@ struct sub_data_s {
   ngx_event_t                   timeout_ev;
 }; //sub_data_t
 
-static ngx_int_t empty_callback(){
+static ngx_int_t empty_callback(ngx_int_t status, void *ptr1, void *ptr2){
   return NGX_OK;
 }
 

--- a/src/subscribers/websocket.c
+++ b/src/subscribers/websocket.c
@@ -213,7 +213,8 @@ struct full_subscriber_s {
   unsigned                awaiting_destruction:1;
 };// full_subscriber_t
 
-static void empty_handler() { }
+static void empty_subscriber_handler(subscriber_t *sub, void *data) { }
+static void empty_cleanup_handler(void *data) { }
 
 static ngx_int_t websocket_send_frame(full_subscriber_t *fsub, const u_char opcode, off_t len, ngx_chain_t *chain);
 static void set_buf_to_str(ngx_buf_t *buf, const ngx_str_t *str);
@@ -279,7 +280,7 @@ static ngx_int_t websocket_finalize_request(full_subscriber_t *fsub) {
   ngx_http_request_t *r = sub->request;
   
   if(fsub->cln) {
-    fsub->cln->handler = (ngx_http_cleanup_pt )empty_handler;
+    fsub->cln->handler = empty_cleanup_handler;
   }
   
   if(sub->cf->unsubscribe_request_url && sub->enqueued) {
@@ -745,10 +746,10 @@ subscriber_t *websocket_subscriber_create(ngx_http_request_t *r, nchan_msg_id_t 
   
   ngx_memzero(&fsub->deflate, sizeof(fsub->deflate));
   
-  fsub->enqueue_callback = empty_handler;
+  fsub->enqueue_callback = empty_subscriber_handler;
   fsub->enqueue_callback_data = NULL;
   
-  fsub->dequeue_callback = empty_handler;
+  fsub->dequeue_callback = empty_subscriber_handler;
   fsub->dequeue_callback_data = NULL;
   fsub->awaiting_destruction = 0;
   


### PR DESCRIPTION
## Description
This PR fixes compilation errors when building nchan with GCC 15 (as used in Fedora 42+). GCC 15 has stricter type checking for function pointer assignments, which causes build failures with the current code.

## Problem
When compiling with GCC 15.2.1, the following errors occur:
```
error: assignment to 'subscriber_callback_pt' from incompatible pointer type 'void (*)(void)'
error: assignment to 'ngx_http_cleanup_pt' from incompatible pointer type 'void (*)(void)' 
error: assignment to 'callback_pt' from incompatible pointer type 'ngx_int_t (*)(void)'
```

## Solution
The fix involves ensuring all function pointers match their expected signatures:

1. **longpoll.c & websocket.c**: Split `empty_handler()` into two properly typed functions:
   - `empty_subscriber_handler(subscriber_t *sub, void *data)` for subscriber callbacks
   - `empty_cleanup_handler(void *data)` for cleanup callbacks

2. **eventsource.c**: Changed `empty_handler(void)` to `empty_cleanup_handler(void *data)`

3. **memstore_ipc.c & memstore.c**: Changed `empty_callback()` to `empty_callback(ngx_int_t status, void *ptr1, void *ptr2)` to match the `callback_pt` typedef

## Testing
Compiles successfully with GCC 15.2.1 on Fedora 42, produces valid ngx_nchan_module.so (2.9MB shared object) with no compilation warnings or errors.

## Important Note
This patch was developed with AI assistance. While it has been tested to compile successfully on the target system and the changes are straightforward type corrections, please review carefully for completeness, security implications, and compatibility with other GCC versions.

## Files Changed
- src/subscribers/longpoll.c
- src/subscribers/websocket.c
- src/subscribers/eventsource.c
- src/subscribers/memstore_ipc.c
- src/store/memory/memstore.c

## Related Issues
This addresses compilation failures on Fedora 42+ and other systems using GCC 15.