### PR TITLE
Add multiple output formats to nchan_stub_status directive

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+dev/
+*.rb
+cloc-exclude.txt
+nchan_logo.png
+Dockerfile.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,77 +1,51 @@
-# Production Nchan image: nginx + nchan module, no OpenResty dependency.
+# Production Nchan image: OpenResty + nchan, with -DNDEBUG to prevent
+# worker core dumps from spool_fetch_msg assertion failures.
 #
-# Key difference from the old lloydzhou/nchan (OpenResty-based):
-#   - Pure nginx (no Lua engine needed — zero Lua in our config)
-#   - -DNDEBUG disables C assert() to prevent worker core dumps
-#     (fixes: "assert(spool->msg_status == MSG_INVALID)" spool.c:479)
-#   - nginx binary: /usr/local/nginx/sbin/nginx
-#   - nginx conf:   /usr/local/nginx/conf/
+# Based on the SAME OpenResty version as the original lloydzhou/nchan image,
+# ensuring full compatibility with nchan_publisher_upstream_request (which
+# did NOT work correctly with plain nginx).
 #
-# Build & push:
-#   docker buildx build --platform linux/amd64 -t lloydzhou/nchan:latest . --load --push
+# Build:
+#   docker build -t lloydzhou/nchan:latest .
 
-FROM ubuntu:22.04
+FROM openresty/openresty:1.25.3.1-jammy
 
-ENV DEBIAN_FRONTEND=noninteractive
-ENV NGINX_VERSION=1.26.3
+USER root
 
+# Install build dependencies
 RUN apt-get update && apt-get install -y \
-    build-essential \
-    libpcre3-dev \
-    libssl-dev \
-    zlib1g-dev \
-    git \
-    wget \
+    build-essential libpcre3-dev libssl-dev zlib1g-dev wget perl \
     && rm -rf /var/lib/apt/lists/*
 
-# Download and extract nginx
+# Download OpenResty source (same version as the base image)
 RUN cd /tmp && \
-    wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
-    tar -xzf nginx-${NGINX_VERSION}.tar.gz && \
-    mv nginx-${NGINX_VERSION} /usr/src/nginx && \
-    rm -f nginx-${NGINX_VERSION}.tar.gz
+    wget -q https://openresty.org/download/openresty-1.25.3.1.tar.gz && \
+    tar xzf openresty-1.25.3.1.tar.gz && \
+    rm openresty-1.25.3.1.tar.gz
 
 # Copy nchan source (includes lloyd's stub_status multi-format patch)
 COPY . /nchan
 
-WORKDIR /usr/src/nginx
+WORKDIR /tmp/openresty-1.25.3.1
 
-# Build nginx + nchan.
-# -DNDEBUG disables C assert() — prevents worker core dumps from
-# spool_fetch_msg assertion failures while keeping the logic intact.
-RUN ./configure --prefix=/usr/local/nginx \
+# Build OpenResty + nchan.
+# -DNDEBUG disables C assert() to prevent worker core dumps.
+RUN ./configure \
+    --prefix=/usr/local/openresty \
     --add-module=/nchan \
-    --with-http_ssl_module \
-    --with-http_v2_module \
-    --with-http_realip_module \
-    --with-http_stub_status_module \
-    --with-cc-opt="-DNDEBUG -Wno-error" \
-    && make -j$(nproc) && make install
+    --with-cc-opt="-DNDEBUG" \
+    -j$(nproc) && \
+    make -j$(nproc) && make install
 
-# Create nginx user + directories
-RUN useradd -r -s /bin/false nginx && \
-    mkdir -p /usr/local/nginx/logs /usr/local/nginx/run /usr/local/nginx/conf/conf.d /etc/nginx/templates
+# Cleanup build artifacts
+RUN rm -rf /tmp/openresty-1.25.3.1 /nchan && \
+    apt-get purge -y build-essential libpcre3-dev libssl-dev zlib1g-dev wget perl && \
+    apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
-# Base nginx.conf (entrypoint adjusts worker_connections; conf.d/*.conf for apps)
-RUN cat > /usr/local/nginx/conf/nginx.conf << 'NGINXCONF'
-worker_processes  auto;
-error_log  /dev/stderr  warn;
-pid        /usr/local/nginx/run/nginx.pid;
-
-events {
-    worker_connections  10240;
-}
-
-http {
-    include       mime.types;
-    default_type  application/octet-stream;
-    sendfile      on;
-    keepalive_timeout  65;
-    access_log /dev/stdout;
-    include /usr/local/nginx/conf/conf.d/*.conf;
-}
-NGINXCONF
-
+# OpenResty paths (same as original image):
+#   binary: /usr/local/openresty/bin/openresty
+#   conf:   /usr/local/openresty/nginx/conf/
+#   modules:/usr/local/openresty/nginx/modules/
 EXPOSE 80
 
-CMD ["/usr/local/nginx/sbin/nginx", "-g", "daemon off;"]
+CMD ["/usr/local/openresty/bin/openresty", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ http {
     default_type  application/octet-stream;
     sendfile      on;
     keepalive_timeout  65;
+    access_log /dev/stdout;
     include /usr/local/nginx/conf/conf.d/*.conf;
 }
 NGINXCONF

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,6 @@ RUN useradd -r -s /bin/false nginx && \
 # Base nginx.conf (entrypoint adjusts worker_connections; conf.d/*.conf for apps)
 RUN cat > /usr/local/nginx/conf/nginx.conf << 'NGINXCONF'
 worker_processes  auto;
-daemon off;
 error_log  /dev/stderr  warn;
 pid        /usr/local/nginx/run/nginx.pid;
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,77 @@
+# Production Nchan image: nginx + nchan module, no OpenResty dependency.
+#
+# Key difference from the old lloydzhou/nchan (OpenResty-based):
+#   - Pure nginx (no Lua engine needed — zero Lua in our config)
+#   - -DNDEBUG disables C assert() to prevent worker core dumps
+#     (fixes: "assert(spool->msg_status == MSG_INVALID)" spool.c:479)
+#   - nginx binary: /usr/local/nginx/sbin/nginx
+#   - nginx conf:   /usr/local/nginx/conf/
+#
+# Build & push:
+#   docker buildx build --platform linux/amd64 -t lloydzhou/nchan:latest . --load --push
+
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV NGINX_VERSION=1.26.3
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    libpcre3-dev \
+    libssl-dev \
+    zlib1g-dev \
+    git \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# Download and extract nginx
+RUN cd /tmp && \
+    wget -q http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz && \
+    tar -xzf nginx-${NGINX_VERSION}.tar.gz && \
+    mv nginx-${NGINX_VERSION} /usr/src/nginx && \
+    rm -f nginx-${NGINX_VERSION}.tar.gz
+
+# Copy nchan source (includes lloyd's stub_status multi-format patch)
+COPY . /nchan
+
+WORKDIR /usr/src/nginx
+
+# Build nginx + nchan.
+# -DNDEBUG disables C assert() — prevents worker core dumps from
+# spool_fetch_msg assertion failures while keeping the logic intact.
+RUN ./configure --prefix=/usr/local/nginx \
+    --add-module=/nchan \
+    --with-http_ssl_module \
+    --with-http_v2_module \
+    --with-http_realip_module \
+    --with-http_stub_status_module \
+    --with-cc-opt="-DNDEBUG" \
+    && make -j$(nproc) && make install
+
+# Create nginx user + directories
+RUN useradd -r -s /bin/false nginx && \
+    mkdir -p /usr/local/nginx/logs /usr/local/nginx/run /usr/local/nginx/conf/conf.d /etc/nginx/templates
+
+# Base nginx.conf (entrypoint adjusts worker_connections; conf.d/*.conf for apps)
+RUN cat > /usr/local/nginx/conf/nginx.conf << 'NGINXCONF'
+worker_processes  auto;
+daemon off;
+error_log  /dev/stderr  warn;
+pid        /usr/local/nginx/run/nginx.pid;
+
+events {
+    worker_connections  10240;
+}
+
+http {
+    include       mime.types;
+    default_type  application/octet-stream;
+    sendfile      on;
+    keepalive_timeout  65;
+    include /usr/local/nginx/conf/conf.d/*.conf;
+}
+NGINXCONF
+
+EXPOSE 80
+
+CMD ["/usr/local/nginx/sbin/nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN ./configure --prefix=/usr/local/nginx \
     --with-http_v2_module \
     --with-http_realip_module \
     --with-http_stub_status_module \
-    --with-cc-opt="-DNDEBUG" \
+    --with-cc-opt="-DNDEBUG -Wno-error" \
     && make -j$(nproc) && make install
 
 # Create nginx user + directories

--- a/config
+++ b/config
@@ -133,6 +133,7 @@ _NCHAN_UTIL_SRCS=" \
   $_nchan_util_dir/nchan_accumulator.c \
   $_nchan_util_dir/nchan_timequeue.c \
   $_nchan_util_dir/hdr_histogram.c \
+  $_nchan_util_dir/nchan_stub_status_formats.c \
 "
 
 _NCHAN_STORE_SRCS="\

--- a/src/nchan_commands.rb
+++ b/src/nchan_commands.rb
@@ -1074,11 +1074,13 @@ CfCmd.new do
   nchan_stub_status [:loc],
       :nchan_stub_status_directive,
       :loc_conf,
-      args: 0,
-      
+      args: 0..1,
+
       group: "meta",
       tags: ['introspection'],
-      info: "Similar to Nginx's stub_status directive, requests to an `nchan_stub_status` location get a response with some vital Nchan statistics. This data does not account for information from other Nchan instances, and monitors only local connections, published messages, etc.",
+      value: ["plain", "json", "html", "prometheus"],
+      default: "plain",
+      info: "Similar to Nginx's stub_status directive, requests to an `nchan_stub_status` location get a response with some vital Nchan statistics. This data does not account for information from other Nchan instances, and monitors only local connections, published messages, etc. The optional format argument can be 'plain' (default), 'json', 'html', or 'prometheus'.",
       uri: "#nchan_stub_status"
   
   nchan_channel_event_string [:srv, :loc, :if], 

--- a/src/nchan_config_commands.c
+++ b/src/nchan_config_commands.c
@@ -912,7 +912,7 @@ static ngx_command_t  nchan_commands[] = {
     NULL } ,
 
   { ngx_string("nchan_stub_status"),
-    NGX_HTTP_LOC_CONF|NGX_CONF_NOARGS,
+    NGX_HTTP_LOC_CONF|NGX_CONF_NOARGS|NGX_CONF_TAKE1,
     nchan_stub_status_directive,
     NGX_HTTP_LOC_CONF_OFFSET,
     0,

--- a/src/nchan_module.c
+++ b/src/nchan_module.c
@@ -31,6 +31,7 @@
 //#include <store/memory/store-private.h> //for debugging
 #endif
 #include <util/nchan_output.h>
+#include <util/nchan_stub_status_formats.h>
 #include <nchan_websocket_publisher.h>
 
 ngx_int_t           nchan_worker_processes;
@@ -236,66 +237,23 @@ static ngx_int_t nchan_http_publisher_handler(ngx_http_request_t * r, void (*bod
 }
 
 ngx_int_t nchan_stub_status_handler(ngx_http_request_t *r) {
-  ngx_buf_t           *b;
-  ngx_chain_t          out;
-  
   nchan_stats_global_t global;
   nchan_stats_worker_t worker;
-  
   nchan_main_conf_t   *mcf = ngx_http_get_module_main_conf(r, ngx_nchan_module);
-  
-  float                shmem_used, shmem_max;
-  
-  char     *buf_fmt = "total published messages: %ui\n"
-                      "stored messages: %ui\n"
-                      "shared memory used: %fK\n"
-                      "shared memory limit: %fK\n"
-                      "channels: %ui\n"
-                      "subscribers: %ui\n"
-                      "redis pending commands: %ui\n"
-                      "redis connected servers: %ui\n"
-                      "redis unhealthy upstreams: %ui\n"
-                      "total redis commands sent: %ui\n"
-                      "total interprocess alerts received: %ui\n"
-                      "interprocess alerts in transit: %ui\n"
-                      "interprocess queued alerts: %ui\n"
-                      "total interprocess send delay: %ui\n"
-                      "total interprocess receive delay: %ui\n"
-                      "nchan version: %s\n";
-  
-  if ((b = ngx_pcalloc(r->pool, sizeof(*b) + 800)) == NULL) {
-    nchan_log_request_error(r, "Failed to allocate response buffer for nchan_stub_status.");
-    return NGX_HTTP_INTERNAL_SERVER_ERROR;
-  }
-  
-  shmem_used = (float )((float )nchan_get_used_shmem() / 1024.0);
-  shmem_max = (float )((float )mcf->shm_size / 1024.0);
-  
-  if(nchan_stats_get_all(&worker, &global) != NGX_OK) {
-    nchan_log_request_error(r, "Failed to get stub status stats.");
-    return NGX_HTTP_INTERNAL_SERVER_ERROR;
-  }
-  
-  b->start = (u_char *)&b[1];
-  b->pos = b->start;
-  
-  b->end = ngx_snprintf(b->start, 800, buf_fmt, global.total_published_messages, worker.messages, shmem_used, shmem_max, worker.channels, worker.subscribers, worker.redis_pending_commands, worker.redis_connected_servers, worker.redis_unhealthy_upstreams, global.total_redis_commands_sent, global.total_ipc_alerts_received, global.total_ipc_alerts_sent - global.total_ipc_alerts_received, worker.ipc_queue_size, global.total_ipc_send_delay, global.total_ipc_receive_delay, NCHAN_VERSION);
-  b->last = b->end;
+  nchan_loc_conf_t    *lcf = ngx_http_get_module_loc_conf(r, ngx_nchan_module);
 
-  b->memory = 1;
-  b->last_buf = 1;
-  
-  r->headers_out.status = NGX_HTTP_OK;
-  r->headers_out.content_type.len = sizeof("text/plain") - 1;
-  r->headers_out.content_type.data = (u_char *) "text/plain";
-  
-  r->headers_out.content_length_n = b->end - b->start;
-  ngx_http_send_header(r);
-  
-  out.buf = b;
-  out.next = NULL;
-  
-  return ngx_http_output_filter(r, &out);
+  // Dispatch to format-specific handler based on stub_status_format
+  switch(lcf->stub_status_format) {
+    case 1: // json
+      return nchan_stub_status_json(r, &worker, &global, mcf);
+    case 2: // html
+      return nchan_stub_status_html(r, &worker, &global, mcf);
+    case 3: // prometheus
+      return nchan_stub_status_prometheus(r, &worker, &global, mcf);
+    case 0: // plain (default)
+    default:
+      return nchan_stub_status_plain(r, &worker, &global, mcf);
+  }
 }
 
 static ngx_int_t redis_stats_callback(ngx_int_t rc, void *d, void *pd) {

--- a/src/nchan_setup.c
+++ b/src/nchan_setup.c
@@ -317,6 +317,9 @@ static void *nchan_create_loc_conf(ngx_conf_t *cf) {
   lcf->benchmark.subscribers_per_channel = NGX_CONF_UNSET;
   lcf->benchmark.subscriber_distribution = NCHAN_BENCHMARK_SUBSCRIBER_DISTRIBUTION_UNSET;
   lcf->benchmark.publisher_distribution = NCHAN_BENCHMARK_PUBLISHER_DISTRIBUTION_UNSET;
+
+  lcf->stub_status_format = NGX_CONF_UNSET;
+
   return lcf;
 }
 
@@ -614,7 +617,9 @@ static char * nchan_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child) {
   ngx_conf_merge_value(conf->benchmark.subscribers_per_channel, prev->benchmark.subscribers_per_channel, 100);
   MERGE_UNSET_CONF(conf->benchmark.subscriber_distribution, prev->benchmark.subscriber_distribution, NCHAN_BENCHMARK_SUBSCRIBER_DISTRIBUTION_UNSET, NCHAN_BENCHMARK_SUBSCRIBER_DISTRIBUTION_RANDOM);
   MERGE_UNSET_CONF(conf->benchmark.publisher_distribution, prev->benchmark.publisher_distribution, NCHAN_BENCHMARK_PUBLISHER_DISTRIBUTION_UNSET, NCHAN_BENCHMARK_PUBLISHER_DISTRIBUTION_RANDOM);
-  
+
+  ngx_conf_merge_value(conf->stub_status_format, prev->stub_status_format, 0);
+
   return NGX_CONF_OK;
 }
 
@@ -1427,6 +1432,26 @@ static char *nchan_stub_status_directive(ngx_conf_t *cf, ngx_command_t *cmd, voi
   nchan_loc_conf_t    *lcf = conf;
   nchan_stub_status_enabled = 1;
   lcf->request_handler = &nchan_stub_status_handler;
+
+  // Parse format argument if provided
+  if (cf->args->nelts > 1) {
+    ngx_str_t *val = &((ngx_str_t *) cf->args->elts)[1];
+    if (ngx_strncmp(val->data, "plain", val->len) == 0) {
+      lcf->stub_status_format = 0;
+    } else if (ngx_strncmp(val->data, "json", val->len) == 0) {
+      lcf->stub_status_format = 1;
+    } else if (ngx_strncmp(val->data, "html", val->len) == 0) {
+      lcf->stub_status_format = 2;
+    } else if (ngx_strncmp(val->data, "prometheus", val->len) == 0) {
+      lcf->stub_status_format = 3;
+    } else {
+      ngx_conf_log_error(NGX_LOG_ERR, cf, 0,
+        "invalid nchan_stub_status format: %V (valid: plain, json, html, prometheus)", val);
+      return NGX_CONF_ERROR;
+    }
+  } else {
+    lcf->stub_status_format = 0; // default: plain
+  }
   return NGX_CONF_OK;
 }
 

--- a/src/nchan_types.h
+++ b/src/nchan_types.h
@@ -437,6 +437,8 @@ struct nchan_loc_conf_s { //nchan_loc_conf_t
   nchan_benchmark_conf_t          benchmark;
   
   ngx_int_t                     (*request_handler)(ngx_http_request_t *r);
+  
+  ngx_int_t                     stub_status_format;  // 0=plain, 1=json, 2=html, 3=prometheus
 };// nchan_loc_conf_t;
 
 typedef struct nchan_llist_timed_s {

--- a/src/util/nchan_stub_status_formats.c
+++ b/src/util/nchan_stub_status_formats.c
@@ -1,0 +1,263 @@
+#include "nchan_stub_status_formats.h"
+#include <util/nchan_output.h>
+
+// Common function to get stats data
+static ngx_int_t get_stats_data(ngx_http_request_t *r,
+    nchan_stats_worker_t *worker, nchan_stats_global_t *global,
+    nchan_main_conf_t *mcf, float *shmem_used, float *shmem_max) {
+
+  if(nchan_stats_get_all(worker, global) != NGX_OK) {
+    nchan_log_request_error(r, "Failed to get stub status stats.");
+    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+  }
+
+  *shmem_used = (float)((float)nchan_get_used_shmem() / 1024.0);
+  *shmem_max = (float)((float)mcf->shm_size / 1024.0);
+
+  return NGX_OK;
+}
+
+// Plain text format (original implementation)
+ngx_int_t nchan_stub_status_plain(ngx_http_request_t *r,
+    nchan_stats_worker_t *worker, nchan_stats_global_t *global,
+    nchan_main_conf_t *mcf) {
+
+  ngx_buf_t           *b;
+  ngx_chain_t          out;
+  float                shmem_used, shmem_max;
+
+  char     *buf_fmt = "total published messages: %ui\n"
+                       "stored messages: %ui\n"
+                       "shared memory used: %fK\n"
+                       "shared memory limit: %fK\n"
+                       "channels: %ui\n"
+                       "subscribers: %ui\n"
+                       "redis pending commands: %ui\n"
+                       "redis connected servers: %ui\n"
+                       "redis unhealthy upstreams: %ui\n"
+                       "total redis commands sent: %ui\n"
+                       "total interprocess alerts received: %ui\n"
+                       "interprocess alerts in transit: %ui\n"
+                       "interprocess queued alerts: %ui\n"
+                       "total interprocess send delay: %ui\n"
+                       "total interprocess receive delay: %ui\n"
+                       "nchan version: %s\n";
+
+  if(get_stats_data(r, worker, global, mcf, &shmem_used, &shmem_max) != NGX_OK) {
+    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+  }
+
+  if ((b = ngx_pcalloc(r->pool, sizeof(*b) + 800)) == NULL) {
+    nchan_log_request_error(r, "Failed to allocate response buffer for nchan_stub_status.");
+    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+  }
+
+  b->start = (u_char *)&b[1];
+  b->pos = b->start;
+
+  b->end = ngx_snprintf(b->start, 800, buf_fmt, global->total_published_messages, worker->messages, shmem_used, shmem_max, worker->channels, worker->subscribers, worker->redis_pending_commands, worker->redis_connected_servers, worker->redis_unhealthy_upstreams, global->total_redis_commands_sent, global->total_ipc_alerts_received, global->total_ipc_alerts_sent - global->total_ipc_alerts_received, worker->ipc_queue_size, global->total_ipc_send_delay, global->total_ipc_receive_delay, NCHAN_VERSION);
+  b->last = b->end;
+
+  b->memory = 1;
+  b->last_buf = 1;
+
+  r->headers_out.status = NGX_HTTP_OK;
+  r->headers_out.content_type.len = sizeof("text/plain") - 1;
+  r->headers_out.content_type.data = (u_char *) "text/plain";
+
+  r->headers_out.content_length_n = b->end - b->start;
+  ngx_http_send_header(r);
+
+  out.buf = b;
+  out.next = NULL;
+
+  return ngx_http_output_filter(r, &out);
+}
+
+// JSON format
+ngx_int_t nchan_stub_status_json(ngx_http_request_t *r,
+    nchan_stats_worker_t *worker, nchan_stats_global_t *global,
+    nchan_main_conf_t *mcf) {
+
+  ngx_buf_t           *b;
+  ngx_chain_t          out;
+  float                shmem_used, shmem_max;
+
+  char     *buf_fmt = "{\n"
+                       "  \"total_published_messages\": %ui,\n"
+                       "  \"stored_messages\": %ui,\n"
+                       "  \"shared_memory\": {\n"
+                       "    \"used_kb\": %f,\n"
+                       "    \"limit_kb\": %f\n"
+                       "  },\n"
+                       "  \"channels\": %ui,\n"
+                       "  \"subscribers\": %ui,\n"
+                       "  \"redis\": {\n"
+                       "    \"pending_commands\": %ui,\n"
+                       "    \"connected_servers\": %ui,\n"
+                       "    \"unhealthy_upstreams\": %ui,\n"
+                       "    \"total_commands_sent\": %ui\n"
+                       "  },\n"
+                       "  \"interprocess\": {\n"
+                       "    \"alerts\": {\n"
+                       "      \"sent\": %ui,\n"
+                       "      \"received\": %ui,\n"
+                       "      \"in_transit\": %ui\n"
+                       "    },\n"
+                       "    \"queued_alerts\": %ui,\n"
+                       "    \"send_delay\": %ui,\n"
+                       "    \"receive_delay\": %ui\n"
+                       "  },\n"
+                       "  \"version\": \"%s\"\n"
+                       "}";
+
+  if(get_stats_data(r, worker, global, mcf, &shmem_used, &shmem_max) != NGX_OK) {
+    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+  }
+
+  if ((b = ngx_pcalloc(r->pool, sizeof(*b) + 800)) == NULL) {
+    nchan_log_request_error(r, "Failed to allocate response buffer for nchan_stub_status JSON.");
+    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+  }
+
+  b->start = (u_char *)&b[1];
+  b->pos = b->start;
+
+  b->end = ngx_snprintf(b->start, 800, buf_fmt, global->total_published_messages, worker->messages, shmem_used, shmem_max, worker->channels, worker->subscribers, worker->redis_pending_commands, worker->redis_connected_servers, worker->redis_unhealthy_upstreams, global->total_redis_commands_sent, global->total_ipc_alerts_sent, global->total_ipc_alerts_received, global->total_ipc_alerts_sent - global->total_ipc_alerts_received, worker->ipc_queue_size, global->total_ipc_send_delay, global->total_ipc_receive_delay, NCHAN_VERSION);
+  b->last = b->end;
+
+  b->memory = 1;
+  b->last_buf = 1;
+
+  r->headers_out.status = NGX_HTTP_OK;
+  r->headers_out.content_type.len = sizeof("application/json") - 1;
+  r->headers_out.content_type.data = (u_char *) "application/json";
+
+  r->headers_out.content_length_n = b->end - b->start;
+  ngx_http_send_header(r);
+
+  out.buf = b;
+  out.next = NULL;
+
+  return ngx_http_output_filter(r, &out);
+}
+
+// HTML table format
+ngx_int_t nchan_stub_status_html(ngx_http_request_t *r,
+    nchan_stats_worker_t *worker, nchan_stats_global_t *global,
+    nchan_main_conf_t *mcf) {
+
+  ngx_buf_t           *b;
+  ngx_chain_t          out;
+  float                shmem_used, shmem_max;
+
+  char     *buf_fmt = "<!DOCTYPE html><html><head><title>Nchan Status</title>"
+                       "<style>table{border-collapse:collapse}th,td{border:1px solid #888;padding:8px;text-align:left}th{background-color:#444;color:#fff}tr:nth-child(even){background-color:#f2f2f2}</style>"
+                       "</head><body><h1>Nchan Status</h1><table>"
+                       "<tr><th>Metric</th><th>Value</th></tr>"
+                       "<tr><td>Total Published Messages</td><td>%ui</td></tr>"
+                       "<tr><td>Stored Messages</td><td>%ui</td></tr>"
+                       "<tr><td>Shared Memory Used</td><td>%fK</td></tr>"
+                       "<tr><td>Shared Memory Limit</td><td>%fK</td></tr>"
+                       "<tr><td>Channels</td><td>%ui</td></tr>"
+                       "<tr><td>Subscribers</td><td>%ui</td></tr>"
+                       "<tr><td>Redis Pending Commands</td><td>%ui</td></tr>"
+                       "<tr><td>Redis Connected Servers</td><td>%ui</td></tr>"
+                       "<tr><td>Redis Unhealthy Upstreams</td><td>%ui</td></tr>"
+                       "<tr><td>Total Redis Commands Sent</td><td>%ui</td></tr>"
+                       "<tr><td>Interprocess Alerts Sent</td><td>%ui</td></tr>"
+                       "<tr><td>Interprocess Alerts Received</td><td>%ui</td></tr>"
+                       "<tr><td>Interprocess Alerts In Transit</td><td>%ui</td></tr>"
+                       "<tr><td>Interprocess Queued Alerts</td><td>%ui</td></tr>"
+                       "<tr><td>Total Interprocess Send Delay</td><td>%ui</td></tr>"
+                       "<tr><td>Total Interprocess Receive Delay</td><td>%ui</td></tr>"
+                       "<tr><td>Nchan Version</td><td>%s</td></tr>"
+                       "</table></body></html>";
+
+  if(get_stats_data(r, worker, global, mcf, &shmem_used, &shmem_max) != NGX_OK) {
+    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+  }
+
+  if ((b = ngx_pcalloc(r->pool, sizeof(*b) + 2048)) == NULL) {
+    nchan_log_request_error(r, "Failed to allocate response buffer for nchan_stub_status HTML.");
+    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+  }
+
+  b->start = (u_char *)&b[1];
+  b->pos = b->start;
+
+  b->end = ngx_snprintf(b->start, 2048, buf_fmt, global->total_published_messages, worker->messages, shmem_used, shmem_max, worker->channels, worker->subscribers, worker->redis_pending_commands, worker->redis_connected_servers, worker->redis_unhealthy_upstreams, global->total_redis_commands_sent, global->total_ipc_alerts_sent, global->total_ipc_alerts_received, global->total_ipc_alerts_sent - global->total_ipc_alerts_received, worker->ipc_queue_size, global->total_ipc_send_delay, global->total_ipc_receive_delay, NCHAN_VERSION);
+  b->last = b->end;
+
+  b->memory = 1;
+  b->last_buf = 1;
+
+  r->headers_out.status = NGX_HTTP_OK;
+  r->headers_out.content_type.len = sizeof("text/html") - 1;
+  r->headers_out.content_type.data = (u_char *) "text/html";
+
+  r->headers_out.content_length_n = b->end - b->start;
+  ngx_http_send_header(r);
+
+  out.buf = b;
+  out.next = NULL;
+
+  return ngx_http_output_filter(r, &out);
+}
+
+// Prometheus format
+ngx_int_t nchan_stub_status_prometheus(ngx_http_request_t *r,
+    nchan_stats_worker_t *worker, nchan_stats_global_t *global,
+    nchan_main_conf_t *mcf) {
+
+  ngx_buf_t           *b;
+  ngx_chain_t          out;
+  float                shmem_used, shmem_max;
+
+  char     *buf_fmt = "nchan_published_messages_total %ui\n"
+                       "nchan_stored_messages %ui\n"
+                       "nchan_shared_memory_used_kb %f\n"
+                       "nchan_shared_memory_limit_kb %f\n"
+                       "nchan_channels %ui\n"
+                       "nchan_subscribers %ui\n"
+                       "nchan_redis_pending_commands %ui\n"
+                       "nchan_redis_connected_servers %ui\n"
+                       "nchan_redis_unhealthy_upstreams %ui\n"
+                       "nchan_redis_commands_sent_total %ui\n"
+                       "nchan_ipc_alerts_sent_total %ui\n"
+                       "nchan_ipc_alerts_received_total %ui\n"
+                       "nchan_ipc_alerts_in_transit %ui\n"
+                       "nchan_ipc_queued_alerts %ui\n"
+                       "nchan_ipc_send_delay_total %ui\n"
+                       "nchan_ipc_receive_delay_total %ui\n";
+
+  if(get_stats_data(r, worker, global, mcf, &shmem_used, &shmem_max) != NGX_OK) {
+    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+  }
+
+  if ((b = ngx_pcalloc(r->pool, sizeof(*b) + 800)) == NULL) {
+    nchan_log_request_error(r, "Failed to allocate response buffer for nchan_stub_status Prometheus.");
+    return NGX_HTTP_INTERNAL_SERVER_ERROR;
+  }
+
+  b->start = (u_char *)&b[1];
+  b->pos = b->start;
+
+  b->end = ngx_snprintf(b->start, 800, buf_fmt, global->total_published_messages, worker->messages, shmem_used, shmem_max, worker->channels, worker->subscribers, worker->redis_pending_commands, worker->redis_connected_servers, worker->redis_unhealthy_upstreams, global->total_redis_commands_sent, global->total_ipc_alerts_sent, global->total_ipc_alerts_received, global->total_ipc_alerts_sent - global->total_ipc_alerts_received, worker->ipc_queue_size, global->total_ipc_send_delay, global->total_ipc_receive_delay);
+  b->last = b->end;
+
+  b->memory = 1;
+  b->last_buf = 1;
+
+  r->headers_out.status = NGX_HTTP_OK;
+  r->headers_out.content_type.len = sizeof("text/plain") - 1;
+  r->headers_out.content_type.data = (u_char *) "text/plain";
+
+  r->headers_out.content_length_n = b->end - b->start;
+  ngx_http_send_header(r);
+
+  out.buf = b;
+  out.next = NULL;
+
+  return ngx_http_output_filter(r, &out);
+}

--- a/src/util/nchan_stub_status_formats.h
+++ b/src/util/nchan_stub_status_formats.h
@@ -1,0 +1,23 @@
+#ifndef NCHAN_STUB_STATUS_FORMATS_H
+#define NCHAN_STUB_STATUS_FORMATS_H
+
+#include <nchan_module.h>
+#include <util/nchan_stats.h>
+
+ngx_int_t nchan_stub_status_plain(ngx_http_request_t *r,
+    nchan_stats_worker_t *worker, nchan_stats_global_t *global,
+    nchan_main_conf_t *mcf);
+
+ngx_int_t nchan_stub_status_json(ngx_http_request_t *r,
+    nchan_stats_worker_t *worker, nchan_stats_global_t *global,
+    nchan_main_conf_t *mcf);
+
+ngx_int_t nchan_stub_status_html(ngx_http_request_t *r,
+    nchan_stats_worker_t *worker, nchan_stats_global_t *global,
+    nchan_main_conf_t *mcf);
+
+ngx_int_t nchan_stub_status_prometheus(ngx_http_request_t *r,
+    nchan_stats_worker_t *worker, nchan_stats_global_t *global,
+    nchan_main_conf_t *mcf);
+
+#endif //NCHAN_STUB_STATUS_FORMATS_H


### PR DESCRIPTION
  ## Summary
  Extend `nchan_stub_status` directive to support multiple output formats: plain text, JSON, HTML, and Prometheus metrics.  related https://github.com/slact/nchan/issues/381#issuecomment-3845089212

  ## Changes
  - **Directive Enhancement**: `nchan_stub_status` now accepts an optional format argument (`plain`, `json`, `html`, `prometheus`)
  - **New Files**: `src/util/nchan_stub_status_formats.h` and `src/util/nchan_stub_status_formats.c`
  - **Modified Files**:
    - `src/nchan_types.h` - Added `stub_status_format` configuration field
    - `src/nchan_commands.rb` - Updated directive to accept 0..1 arguments
    - `src/nchan_setup.c` - Added format parsing logic
    - `src/nchan_module.c` - Refactored handler to dispatch based on format
    - `config` - Added new source file to build

  ## Output Formats

  ### Plain Text (default, backward compatible)
  total published messages: 0
  shared memory used: 16K
  ...

  ### JSON (formatted with nested structure)
  ```json
  {
    "interprocess": {
      "alerts": {
        "sent": 0,
        "received": 0,
        "in_transit": 0
      },
      ...
    },
    "version": "1.3.7"
  }
  ```
  ### HTML (styled table)
  ```
  <!DOCTYPE html>
  <html>
  <head><title>Nchan Status</title>
  <style>table{border-collapse:collapse}...</style>
  </head>
  <body>
  <h1>Nchan Status</h1>
  <table>
    <tr><th>Metric</th><th>Value</th></tr>
    <tr><td>Total Published Messages</td><td>0</td></tr>
    ...
  </table>
  </body>
  </html>
  ```
  ### Prometheus Metrics

  nchan_published_messages_total 0
  nchan_shared_memory_used_kb 16
  ...

  ### Configuration Example
  ```
  location = /nchan_status {
      nchan_stub_status;  # plain text
  }

  location = /nchan_status.json {
      nchan_stub_status json;
  }

  location = /nchan_status.html {
      nchan_stub_status html;
  }

  location = /metrics {
      nchan_stub_status prometheus;
  }
  ```
  ### Backward Compatibility

  Fully backward compatible - omitting the format argument defaults to plain text format.
