### PR TITLE
src/store/redis/hiredis/sds.c: Fix integer overflow (CVE-2021-21309).

### DIFF
--- a/src/store/redis/hiredis/sds.c
+++ b/src/store/redis/hiredis/sds.c
@@ -93,6 +93,7 @@ sds sdsnewlen(const void *init, size_t initlen) {
     int hdrlen = sdsHdrSize(type);
     unsigned char *fp; /* flags pointer. */
 
+    assert(initlen + hdrlen + 1 > initlen); /* Catch size_t overflow */
     sh = s_malloc(hdrlen+initlen+1);
     if (sh == NULL) return NULL;
     if (!init)
@@ -209,6 +210,7 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
     len = sdslen(s);
     sh = (char*)s-sdsHdrSize(oldtype);
     newlen = (len+addlen);
+    assert(newlen > len);   /* Catch size_t overflow */
     if (newlen < SDS_MAX_PREALLOC)
         newlen *= 2;
     else
@@ -222,6 +224,7 @@ sds sdsMakeRoomFor(sds s, size_t addlen) {
     if (type == SDS_TYPE_5) type = SDS_TYPE_8;
 
     hdrlen = sdsHdrSize(type);
+    assert(hdrlen + newlen + 1 > len);  /* Catch size_t overflow */
     if (oldtype==type) {
         newsh = s_realloc(sh, hdrlen+newlen+1);
         if (newsh == NULL) return NULL;


### PR DESCRIPTION
Hi Nchan Development Team,

Our tool identified a potential vulnerability in clone functions `sdsMakeRoomFor()` and `sdsnewlen()` in `src/store/redis/hiredis/sds.c` sourced from [redis/redis](https://github.com/redis/redis). These issues, originally reported in [CVE-2021-21309](https://nvd.nist.gov/vuln/detail/CVE-2021-21309), were resolved in the repository via this commit https://github.com/redis/redis/commit/c992857618db99776917f10bf4f2345a5fdc78b0.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience.